### PR TITLE
Added client access-type configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ This is request to create 100 new clients in the realm `realm-5` . Each client w
 like <<client_id>>-secret (For example `client-156-secret` in case of the client `client-156`):
 
     http://localhost:8080/auth/realms/master/dataset/create-clients?count=200&realm-name=realm-5
+
+You can also configure the access-type (`bearer-only`, `confidential` or `public`) and whether the client should be a
+service-account-client with these two parameters:
+
+    ...&client-access-type=bearer-only&service-account-client=false
  
 ### Create many users
    

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -942,17 +942,30 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             client.setClientId(clientId);
             client.setName(clientId);
             client.setEnabled(true);
-            client.setServiceAccountsEnabled(true);
             client.setDirectAccessGrantsEnabled(true);
             client.setSecret(clientId.concat("-secret"));
             client.setRedirectUris(Arrays.asList("*"));
-            client.setPublicClient(false);
             client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+
+            switch(config.getClientAccessType()) {
+                case "bearer-only":
+                    client.setBearerOnly(true);
+                    break;
+                case "public":
+                    client.setPublicClient(true);
+                    break;
+                case "confidential":
+                default:
+                    client.setPublicClient(false);
+                    break;
+            }
 
             ClientModel model = ClientManager.createClient(session, realm, client);
 
             // Enable service account
-            new ClientManager(new RealmManager(session)).enableServiceAccount(model);
+            if(Boolean.parseBoolean(config.getIsServiceAccountClient())) {
+                new ClientManager(new RealmManager(session)).enableServiceAccount(model);
+            }
 
             context.clientCreated(model);
 

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
@@ -90,6 +90,14 @@ public class DatasetConfig {
     @QueryParamFill(paramName = "client-role-prefix", defaultValue = "client-role-", operations = { CREATE_REALMS, CREATE_CLIENTS, CREATE_USERS })
     private String clientRolePrefix;
 
+    // Check if created clients should be service account clients
+    @QueryParamFill(paramName = "client-access-type", defaultValue = "confidential", operations = {CREATE_REALMS, CREATE_CLIENTS})
+    private String clientAccessType;
+
+    // Check if created clients should be service account clients
+    @QueryParamFill(paramName = "service-account-client", defaultValue = "true", operations = {CREATE_REALMS, CREATE_CLIENTS})
+    private String isServiceAccountClient;
+
     // When creating clients, every client will have this amount of client roles created
     @QueryParamIntFill(paramName = "client-roles-per-client", defaultValue = 10, operations = { CREATE_REALMS, CREATE_CLIENTS })
     private Integer clientRolesPerClient;
@@ -263,6 +271,14 @@ public class DatasetConfig {
 
     public Integer getTaskTimeout() {
         return taskTimeout;
+    }
+
+    public String getClientAccessType() {
+        return clientAccessType;
+    }
+
+    public String getIsServiceAccountClient() {
+        return isServiceAccountClient;
     }
 
     public void setToString(String toString) {


### PR DESCRIPTION
This PR introduces request parameters that can modify the access type of a client (public, confidential, bearer only) as well as enabling it as a service-account-client.