### PR TITLE
Fix keycloak-benchmark to run also with keycloak 16

### DIFF
--- a/dataset/src/main/java/org/keycloak/benchmark/cache/CacheResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/cache/CacheResourceProvider.java
@@ -33,8 +33,8 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.benchmark.dataset.TaskResponse;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.connections.infinispan.InfinispanUtil;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.sessions.infinispan.util.InfinispanUtil;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.utils.MediaType;
 

--- a/dataset/src/main/java/org/keycloak/benchmark/cache/RemoteCacheResource.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/cache/RemoteCacheResource.java
@@ -33,8 +33,8 @@ import org.jboss.logging.Logger;
 import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.benchmark.dataset.TaskResponse;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.connections.infinispan.InfinispanUtil;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.sessions.infinispan.util.InfinispanUtil;
 import org.keycloak.utils.MediaType;
 
 /**

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/TaskManager.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/TaskManager.java
@@ -25,8 +25,8 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.commons.api.BasicCache;
 import org.jboss.logging.Logger;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.connections.infinispan.InfinispanUtil;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.sessions.infinispan.util.InfinispanUtil;
 
 /**
  * Management of executed tasks and making sure that there won't be multiple tasks in progress (EG. there is not creation of 1000 realms triggered accidentally 2 times)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <description>Keycloak Benchmark Parent</description>
 
   <properties>
-    <keycloak.version>15.0.2</keycloak.version>
+    <keycloak.version>16.0.0-SNAPSHOT</keycloak.version>
     <jboss-jaxrs-api_2.1_spec>2.0.1.Final</jboss-jaxrs-api_2.1_spec>
     <resteasy.version>3.13.2.Final</resteasy.version>
     <junit.version>4.12</junit.version>


### PR DESCRIPTION
* Introduced InfinispanUtilProxy to abstract access to InfinispanUtil that is located in different packages in KC < 16 and KC >= 16