### PR TITLE
Remove nested transactions

### DIFF
--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -133,11 +133,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             }
 
             // Run this in separate thread to not block HTTP request
-            new Thread(() -> {
-
-                createRealmsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, startIndex, realmEndIndex);
-
-            }).start();
+            new Thread(() -> createRealmsImpl(timerLogger, config, startIndex, realmEndIndex)).start();
             started = true;
 
             return Response.ok(TaskResponse.taskStarted(timerLogger.toString(), getStatusUrl())).build();
@@ -279,11 +275,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             config.setStart(startIndex);
 
             // Run this in separate thread to not block HTTP request
-            new Thread(() -> {
-
-                createClientsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, realm);
-
-            }).start();
+            new Thread(() -> createClientsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, realm)).start();
             started = true;
 
             return Response.ok(TaskResponse.taskStarted(timerLogger.toString(), getStatusUrl())).build();
@@ -377,11 +369,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             config.setStart(startIndex);
 
             // Run this in separate thread to not block HTTP request
-            new Thread(() -> {
-
-                createUsersImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, realm);
-
-            }).start();
+            new Thread(() -> createUsersImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, realm)).start();
             started = true;
 
             return Response.ok(TaskResponse.taskStarted(timerLogger.toString(), getStatusUrl())).build();
@@ -480,11 +468,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             logger.infof("Will create events in the realms '" + config.getRealmPrefix() + "0' - '" + config.getRealmPrefix() + lastRealmIndex + "'");
 
             // Run this in separate thread to not block HTTP request
-            new Thread(() -> {
-
-                createEventsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, lastRealmIndex);
-
-            }).start();
+            new Thread(() -> createEventsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, lastRealmIndex)).start();
             started = true;
 
             return Response.ok(TaskResponse.taskStarted(timerLogger.toString(), getStatusUrl())).build();
@@ -584,11 +568,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             logger.infof("Will create offline sessions in the realms '" + config.getRealmPrefix() + "0' - '" + config.getRealmPrefix() + lastRealmIndex + "'");
 
             // Run this in separate thread to not block HTTP request
-            new Thread(() -> {
-
-                createOfflineSessionsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, lastRealmIndex);
-
-            }).start();
+            new Thread(() -> createOfflineSessionsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config, lastRealmIndex)).start();
             started = true;
 
             return Response.ok(TaskResponse.taskStarted(timerLogger.toString(), getStatusUrl())).build();
@@ -698,11 +678,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             logger.infof("Trigger removing realms with the configuration: %s", config);
 
             // Run this in separate thread to not block HTTP request
-            new Thread(() -> {
-
-                removeRealmsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config);
-
-            }).start();
+            new Thread(() -> removeRealmsImpl(timerLogger, baseSession.getKeycloakSessionFactory(), config)).start();
             started = true;
 
             return Response.ok(TaskResponse.taskStarted(timerLogger.toString(), getStatusUrl())).build();

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/ExecutorHelper.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/ExecutorHelper.java
@@ -46,13 +46,13 @@ public class ExecutorHelper {
         this.config = config;
     }
 
+    public void addTask(Runnable task) {
+        Future f = executor.submit(task);
+        futures.add(f);
+    }
 
-    public void addTask(KeycloakSessionTask sessionTask) {
-        Future f = executor.submit(() -> {
-
-            KeycloakModelUtils.runJobInTransactionWithTimeout(sessionFactory, sessionTask, config.getTransactionTimeoutInSeconds());
-
-        });
+    public void addTaskRunningInTransaction(KeycloakSessionTask sessionTask) {
+        Future f = executor.submit(() -> KeycloakModelUtils.runJobInTransactionWithTimeout(sessionFactory, sessionTask, config.getTransactionTimeoutInSeconds()));
         futures.add(f);
     }
 

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/TaskManager.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/TaskManager.java
@@ -53,8 +53,7 @@ public class TaskManager {
 
     public String addTaskIfNotInProgress(TimerLogger task, int taskTimeoutInSeconds) {
         String str = task.toString();
-        String existing = workCache.putIfAbsent(KEY, str, taskTimeoutInSeconds, TimeUnit.SECONDS);
-        return existing;
+        return workCache.putIfAbsent(KEY, str, taskTimeoutInSeconds, TimeUnit.SECONDS);
     }
 
     public void removeExistingTask(boolean successfullyFinished) {


### PR DESCRIPTION
Hi,

we noticed that the dataset SPI uses some kind of nested transactions here and there (Nesting `KeycloakModelUtils.runJobInTransactionWithTimeout()` method calls). Not sure why this is the case. Sometimes when creating a big set of data we got some Exceptions related to transactions. These exceptions went away when changing to flat transactions (remove the nesting of `KeycloakModelUtils.runJobInTransactionWithTimeout()` method calls). Also it simplifies the code.

Do you know why there is nesting of this method in place? I did a few tests what happens when the outer or inner transaction fails but couldn't make sense of it. It seems that only the innermost transaction is working (or at least performs rollbacks).

Kind regards
Benjamin