### PR TITLE
Update dependencies to run with 16.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
   <description>Keycloak Benchmark Parent</description>
 
   <properties>
-    <keycloak.version>16.0.0-SNAPSHOT</keycloak.version>
+    <keycloak.version>16.1.0</keycloak.version>
     <jboss-jaxrs-api_2.1_spec>2.0.1.Final</jboss-jaxrs-api_2.1_spec>
-    <resteasy.version>3.13.2.Final</resteasy.version>
-    <junit.version>4.12</junit.version>
+    <resteasy.version>3.15.1.Final</resteasy.version>
+    <junit.version>4.13.2</junit.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Hi,
using "16.0.0-SNAPSHOT" doesn't work anymore and bumping the versions to "16.1.0" resolves the issues so here's the required adjustment for that.
Cheers