### PR TITLE
Reduce memory footprint when creating many users and clients.

### DIFF
--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -187,9 +187,9 @@ public class DatasetResourceProvider implements RealmResourceProvider {
 
                         }, config.getTransactionTimeoutInSeconds());
 
-                        timerLogger.debug(logger, "Created %d clients in realm %s", context.getClients().size(), context.getRealm().getName());
+                        timerLogger.debug(logger, "Created %d clients in realm %s", context.getClientCount(), context.getRealm().getName());
                     }
-                    timerLogger.info(logger, "Created all %d clients in realm %s", context.getClients().size(), context.getRealm().getName());
+                    timerLogger.info(logger, "Created all %d clients in realm %s", context.getClientCount(), context.getRealm().getName());
 
                     // Step 3 - cache realm. This will cache the realm in Keycloak cache (looks like best regarding performance to do it in separate transaction)
                     cacheRealmAndPopulateContext(context);
@@ -206,10 +206,10 @@ public class DatasetResourceProvider implements RealmResourceProvider {
 
                         }, config.getTransactionTimeoutInSeconds());
 
-                        timerLogger.debug(logger, "Created %d users in realm %s", context.getUsers().size(), context.getRealm().getName());
+                        timerLogger.debug(logger, "Created %d users in realm %s", context.getUserCount(), context.getRealm().getName());
                     }
 
-                    timerLogger.info(logger, "Created all %d users in realm %s. Finished creation of realm.", context.getUsers().size(), context.getRealm().getName());
+                    timerLogger.info(logger, "Created all %d users in realm %s. Finished creation of realm.", context.getUserCount(), context.getRealm().getName());
                 });
 
             }
@@ -306,7 +306,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
                     timerLogger.debug(logger, "Created clients in realm %s from %d to %d", context.getRealm().getName(), clientsStartIndex, endIndex);
 
                     if (((endIndex - startIndex) / config.getClientsPerTransaction()) % 20 == 0) {
-                        timerLogger.info(logger, "Created %d clients in realm %s", context.getClients().size(), context.getRealm().getName());
+                        timerLogger.info(logger, "Created %d clients in realm %s", context.getClientCount(), context.getRealm().getName());
                     }
 
                 });
@@ -315,7 +315,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
 
             executor.waitForAllToFinish();
 
-            timerLogger.info(logger, "Created all %d clients in realm %s", context.getClients().size(), context.getRealm().getName());
+            timerLogger.info(logger, "Created all %d clients in realm %s", context.getClientCount(), context.getRealm().getName());
         } finally {
             executor.shutDown();
             new TaskManager(baseSession).removeExistingTask(true);
@@ -401,7 +401,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
                     timerLogger.debug(logger, "Created users in realm %s from %d to %d", context.getRealm().getName(), usersStartIndex, endIndex);
 
                     if (((endIndex - startIndex) / config.getUsersPerTransaction()) % 20 == 0) {
-                        timerLogger.info(logger, "Created %d users in realm %s", context.getUsers().size(), context.getRealm().getName());
+                        timerLogger.info(logger, "Created %d users in realm %s", context.getUserCount(), context.getRealm().getName());
                     }
 
                 });
@@ -410,7 +410,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
 
             executor.waitForAllToFinish();
 
-            timerLogger.info(logger, "Created all %d users in realm %s", context.getUsers().size(), context.getRealm().getName());
+            timerLogger.info(logger, "Created all %d users in realm %s", context.getUserCount(), context.getRealm().getName());
 
         } finally {
             executor.shutDown();
@@ -900,7 +900,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
                 new ClientManager(new RealmManager(session)).enableServiceAccount(model);
             }
 
-            context.clientCreated(model);
+            context.incClientCount();
 
             for (int k = 0; k < config.getClientRolesPerClient() ; k++) {
                 String roleName = clientId + "-" + config.getClientRolePrefix() + k;
@@ -909,7 +909,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             }
         }
 
-        timerLogger.debug(logger, "Created %d clients in realm %s", context.getClients().size(), context.getRealm().getName());
+        timerLogger.debug(logger, "Created %d clients in realm %s", context.getClientCount(), context.getRealm().getName());
     }
 
     private void createGroups(RealmContext context) {
@@ -966,7 +966,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
                 logger.tracef("Assigned group %s to the user %s", context.getGroups().get(groupIndex).getName(), user.getUsername());
             }
 
-            context.userCreated(user);
+            context.incUserCount();
         }
     }
 
@@ -1038,7 +1038,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             });
 
             logger.debugf("CACHE: After client roles loaded in the realm %s", realm.getName());
-            context.setClients(sortedClients);
+            context.setClientCount(sortedClients.size());
             context.setClientRoles(sortedClientRoles);
 
         }, config.getTransactionTimeoutInSeconds());

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/RealmContext.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/RealmContext.java
@@ -21,13 +21,13 @@ package org.keycloak.benchmark.dataset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.keycloak.benchmark.dataset.config.DatasetConfig;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserModel;
 
 /**
  * Collection of objects, which were created and are related to the particular realm. This collection is "maintained" here to avoid
@@ -43,8 +43,8 @@ public class RealmContext {
 
     private RealmModel realm;
 
-    private List<ClientModel> clients = Collections.synchronizedList(new ArrayList<>());
-
+    private final AtomicLong clientsCount = new AtomicLong();
+    
     private List<RoleModel> realmRoles = new ArrayList<>();
 
     // All client roles of all clients
@@ -52,7 +52,7 @@ public class RealmContext {
 
     private List<GroupModel> groups = new ArrayList<>();
 
-    private final List<UserModel> users = Collections.synchronizedList(new ArrayList<>());
+    private final AtomicLong usersCount = new AtomicLong();
 
     public RealmContext(DatasetConfig config) {
         this.config = config;
@@ -70,18 +70,18 @@ public class RealmContext {
         this.realm = realm;
     }
 
-    public void clientCreated(ClientModel client) {
-        clients.add(client);
+    public void incClientCount() {
+        clientsCount.incrementAndGet();
     }
 
-    public List<ClientModel> getClients() {
-        return clients;
+    public void setClientCount(long clientCount) {
+        clientsCount.set(clientCount);
     }
 
-    public void setClients(List<ClientModel> clients) {
-        this.clients = Collections.synchronizedList(clients);
+    public long getClientCount() {
+        return clientsCount.get();
     }
-
+    
     public void realmRoleCreated(RoleModel role) {
         realmRoles.add(role);
     }
@@ -118,11 +118,11 @@ public class RealmContext {
         this.groups = groups;
     }
 
-    public void userCreated(UserModel user) {
-        this.users.add(user);
+    public void incUserCount() {
+        this.usersCount.incrementAndGet();
     }
 
-    public List<UserModel> getUsers() {
-        return users;
+    public long getUserCount() {
+        return this.usersCount.get();
     }
 }


### PR DESCRIPTION
We realized that the dataset spi consumes a huge amount of memory when many users and clients are created.
This may change the behaviour of the running keycloak instance and has also a negative  impact on performance while creating test data.
Since the lists are currently only used to get the item count I replaced them with a counters.

Closes #37 
