### PR TITLE
Ability to chose the Gatling workload mode (open/closed).

### DIFF
--- a/benchmark/src/main/java/org/keycloak/benchmark/WorkloadModel.java
+++ b/benchmark/src/main/java/org/keycloak/benchmark/WorkloadModel.java
@@ -1,0 +1,12 @@
+package org.keycloak.benchmark;
+
+/**
+ *
+ * @author tkyjovsk
+ */
+public enum WorkloadModel {
+
+    OPEN, // load generation defined by user arrival rate (usersPerSec)
+    CLOSED // loag generation defined by number of concurrent users (concurrentUsers)
+
+}


### PR DESCRIPTION
This PR adds an ability to chose the [Gatling operating mode](https://gatling.io/2018/10/gatling-3-closed-workload-model-support/).

By providing `--users-per-sec` parameter user choses the "open" workload mode.
By providing `--concurrent-users` parameter user choses the "closed" workload mode.