### PR TITLE
Replaced `maxFailedRequests` SLA assertion with `maxErrorPercentage`.

### DIFF
--- a/benchmark/src/main/java/org/keycloak/benchmark/Config.java
+++ b/benchmark/src/main/java/org/keycloak/benchmark/Config.java
@@ -126,7 +126,7 @@ public class Config {
     public static final String serverUris;
     public static final List<String> serverUrisList;
     // assertion properties
-    public static final int maxFailedRequests = Integer.getInteger("sla-failed-requests", 0);
+    public static final double maxErrorPercentage = Double.valueOf(System.getProperty("sla-error-percentage", "0"));
     public static final int maxMeanReponseTime = Integer.getInteger("sla-mean-response-time", 300);
     public static SimpleDateFormat SIMPLE_TIME = new SimpleDateFormat("HH:mm:ss");
 
@@ -194,9 +194,9 @@ public class Config {
     }
 
     public static String toStringSLA() {
-        return String.format("  Failed Requests: %s\n"
-                        + "  Mean Response Time: %s",
-                maxFailedRequests,
+        return String.format("  Max Error Percentage: %s\n"
+                           + "  Max Mean Response Time: %s",
+                maxErrorPercentage,
                 maxMeanReponseTime);
     }
 

--- a/benchmark/src/main/scala/keycloak/scenario/CommonSimulation.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/CommonSimulation.scala
@@ -51,8 +51,9 @@ abstract class CommonSimulation extends Simulation {
           )
       ).protocols(defaultHttpProtocol())
     ).assertions(
-      global.failedRequests.count.lt(Config.maxFailedRequests + 1),
-      global.responseTime.mean.lt(Config.maxMeanReponseTime))
+      global.failedRequests.percent.lte(Config.maxErrorPercentage),
+      global.responseTime.mean.lte(Config.maxMeanReponseTime)
+    )
 
   }
 

--- a/benchmark/src/main/scala/keycloak/scenario/_private/OIDCRegisterAndLogoutSimulation.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/_private/OIDCRegisterAndLogoutSimulation.scala
@@ -14,8 +14,8 @@ class OIDCRegisterAndLogoutSimulation extends CommonSimulation {
     constantUsersPerSec(Config.usersPerSec) during (Config.warmUpPeriod + Config.measurementPeriod)).protocols(defaultHttpProtocol()))
 
     .assertions(
-      global.failedRequests.count.lt(Config.maxFailedRequests + 1),
-      global.responseTime.mean.lt(Config.maxMeanReponseTime)
+      global.failedRequests.percent.lte(Config.maxErrorPercentage),
+      global.responseTime.mean.lte(Config.maxMeanReponseTime)
     )
 
 }

--- a/benchmark/src/main/scala/keycloak/scenario/admin/UserCrawl.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/UserCrawl.scala
@@ -16,8 +16,8 @@ class UserCrawl extends CommonSimulation {
     .protocols(defaultHttpProtocol()))
 
     .assertions(
-      global.failedRequests.count.lt(Config.maxFailedRequests + 1),
-      global.responseTime.mean.lt(Config.maxMeanReponseTime)
+      global.failedRequests.percent.lte(Config.maxErrorPercentage),
+      global.responseTime.mean.lte(Config.maxMeanReponseTime)
     )
 
 }


### PR DESCRIPTION
Replacing assertion for maximum number of failed requests with maximum request error percentage.