### PR TITLE
Fix parameter passed to list clients endpoint

### DIFF
--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -320,7 +320,7 @@ class KeycloakScenarioBuilder {
       .exec(http("List clients")
         .get(ADMIN_ENDPOINT + "/clients")
         .header("Authorization", "Bearer ${token}")
-        .queryParam("maxResults", 2)
+        .queryParam("max", 2)
         .check(status.is(200)))
       .exitHereIfFailed
     this


### PR DESCRIPTION
This fixes the behavior observed in the test. 

This now uses the correct parameter, as seen in [ClientsResouce](https://github.com/keycloak/keycloak/blob/7335abaf08915d364f16667733237aa8ac8a3b0f/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java#L109): 

```
    public Stream<ClientRepresentation> getClients(@QueryParam("clientId") String clientId,
                                                 @QueryParam("viewableOnly") @DefaultValue("false") boolean viewableOnly,
                                                 @QueryParam("search") @DefaultValue("false") boolean search,
                                                 @QueryParam("q") String searchQuery,
                                                 @QueryParam("first") Integer firstResult,
                                                 @QueryParam("max") Integer maxResults) {
```

Closes #51