### PR TITLE
Configure HTTP logging via script arguments instead of logback.xml changes (fixes #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ To use a different server URL and scenario:
 You can set different options to change how tests should be executed. For a complete list of the available options, see
 [Config](benchmark/src/main/java/org/keycloak/benchmark/Config.java).
 
+### Logging
+
+You can enable HTTP logging using the following additional options:
+* `--log-http-on-failure`: HTTP requests and responses will be logged when the scenario expectations are not met
+* `--log-http-always`: HTTP requests and responses will *always* be logged
+
 ### Report
 
 Check reports at the `result` directory.

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -8,7 +8,8 @@
 
     <properties>
         <scala.version>2.12.10</scala.version>
-        <gatling.version>3.4.0</gatling.version>
+        <gatling.version>3.4.2</gatling.version>
+        <janino.version>3.1.7</janino.version>
         <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -24,6 +25,11 @@
             <groupId>io.gatling.highcharts</groupId>
             <artifactId>gatling-charts-highcharts</artifactId>
             <version>${gatling.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>${janino.version}</version>
         </dependency>
     </dependencies>
 

--- a/benchmark/src/main/resources/logback.xml
+++ b/benchmark/src/main/resources/logback.xml
@@ -22,9 +22,19 @@
         <appender-ref ref="CONSOLE"/>
     </root>
 
-    <!-- Uncomment for logging ALL HTTP request and responses -->
-    <!-- 	<logger name="io.gatling.http" level="TRACE" /> -->
-    <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
+    <if condition='isDefined("log-http-on-failure")'>
+    <then>
+       <!-- Logging ONLY FAILED HTTP request and responses -->
+        <logger name="io.gatling.http.engine.response" level="DEBUG" />
+    </then>
+    </if>
+    <if condition='isDefined("log-http-always")'>
+    <then>
+       <!-- Logging ALL HTTP request and responses -->
+        <logger name="io.gatling.http.engine.response" level="TRACE" />
+    </then>
+    </if>
+
     <logger name="io.gatling" level="WARN"/>
 
     <logger name="org.keycloak" level="WARN" additivity="false">


### PR DESCRIPTION
* Upgraded `gatling` 3.4.0 -> 3.4.2 to include changes for https://github.com/gatling/gatling/issues/3994
* Added `janino` to enable logback conditional configuration
* Updated logback configuration file to set proper logger levels depending on Java properties
* Added a logging section into README

Closes #54