### PR TITLE
Add a CreateRealms scenario to measure realm creation scalability (fixes #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Before running tests, make sure realms are configured as follows:
 
 * Realms must have `User Registration` setting enabled.
 
-Some scenarios (`CreateDeleteClients` and `CrawlUsers`) require a service account with the clientId `gatling`:
+Some scenarios (`CreateDeleteClients`, and `CrawlUsers`, `CreateRealms`) require a service account with the clientId `gatling`:
 
 * select the realm that is used for testing
 * create a client  with the name `gatling`
@@ -188,6 +188,21 @@ Some scenarios (`CreateDeleteClients` and `CrawlUsers`) require a service accoun
    * select for `realm-management` in the `Client Roles` listbox
    * assign the roles `manage-clients` and `view-users`
 * the client secret to be passed to the tests can be copied from the `Credentials` tab
+
+#### Scenario `keycloak.scenario.admin.CreateRealms`
+
+This scenario requires the following Client settings, in addition to the requirements above:
+
+* In to the `Scopes` tab
+    * Set `Full Scope Allowed` to `Off`
+    * Add role `create-realm` in the `Realm Roles` section
+* In the `Service Account Roles` tab
+    * assign the roles `create-realm` in the `Realm Roles` section
+
+The `Full Scope Allowed` flag is especially important to disable, because if enabled,
+the access token will contain *all* the accesses to all the realms,
+leading to the token becoming too large after roughly 40 created realms
+(receiving `431 Request Header Fields Too Large` responses in this case).
 
 ### Run
 
@@ -219,6 +234,7 @@ These are the available test scenarios:
 * `keycloak.scenario.authentication.ClientSecret`: Client Secret (Client Credentials Grant)
 * `keycloak.scenario.admin.CreateDeleteClients`: Create and deleted clients (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.UserCrawl`: Crawls all users page by page (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateRealms`: Create realms (requires `--client-secret=<client secret for gatling client>` and `--realm-name=master`)
 
 ## Release
 

--- a/benchmark/src/main/scala/keycloak/scenario/admin/CreateRealms.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/CreateRealms.scala
@@ -1,0 +1,12 @@
+package keycloak.scenario.admin
+
+import keycloak.scenario.{CommonSimulation, KeycloakScenarioBuilder}
+
+
+class CreateRealms extends CommonSimulation {
+
+  setUp("CRUD realms", new KeycloakScenarioBuilder()
+    .serviceAccountToken()
+    .createRealm()
+  )
+}


### PR DESCRIPTION
A new scenario is added to perform and measure realm creation performance with Keycloak.

Command-line example for running this scenario:
```
./kcb.sh --scenario=keycloak.scenario.admin.CreateRealms \
  --server-url=http://localhost:8080 \
  --concurrent-users=1 \
  --measurement=300 \
  --realm-name=master \
  --client-secret=<secret>
```

Closes #56 

*Implementation note*

Ensuring realm name and id uniqueness is achieved by adding a property containing a unique ID for each user created to execute the scenario by gatling (using the `Feeder` facility), and using this property into the realm name and id.

This Gatling user property (available from the user Session), named `gatlingUniqueUserId`, can be used elsewhere as well as this is quite generic.

*Documentation note*

When using the document process to create a Keycloak Client for `gatling`, the client is created with flag `Full Scope Allowed` set to `On`, which actually lists all the access to all the realms into the access token, leading to the token becoming too large after roughly 40 created realms (receiving `431 Request Header Fields Too Large` responses in this case).

Instead, this flag must be disabled and appropriate scopes should be set.
Documentation has been updated, but it requires to review the scopes used by the other scenarii - a TODO flag is left in the doc as the placeholder for this list to be discussed in this PR and amended before merging.