### PR TITLE
Add Roles and Groups to the CRUD scenarios to support new store tests

### DIFF
--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -303,6 +303,57 @@ class KeycloakScenarioBuilder {
       })
   }
 
+  //Roles
+  def listRoles(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .exec(http("List Roles")
+        .get(ADMIN_ENDPOINT + "/roles")
+        .header("Authorization", "Bearer ${token}")
+        .queryParam("max", 2)
+        .check(status.is(200)))
+      .exitHereIfFailed
+    this
+  }
+
+  def createRoles(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .exec(_.set("createdRoleId", randomUUID()))
+      .exec(http("Create roles")
+        .post(ADMIN_ENDPOINT + "/roles")
+        .header("Authorization", "Bearer ${token}")
+        .header("Content-Type", "application/json")
+        .check(status.is(201))
+        .check(header("Location").notNull.saveAs("roleLocation")))
+      .exitHereIfFailed
+    this
+  }
+
+  //Groups
+  def listGroups(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .exec(http("List groups")
+        .get(ADMIN_ENDPOINT + "/groups")
+        .header("Authorization", "Bearer ${token}")
+        .queryParam("max", 2)
+        .check(status.is(200)))
+      .exitHereIfFailed
+    this
+  }
+
+  def createGroups(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .exec(_.set("createdGroupId", randomUUID()))
+      .exec(http("Create groups")
+        .post(ADMIN_ENDPOINT + "/groups")
+        .header("Authorization", "Bearer ${token}")
+        .header("Content-Type", "application/json")
+        .body(StringBody("""{ "name" : "${createdGroupId}" }"""))
+        .check(status.is(201))
+        .check(header("Location").notNull.saveAs("groupLocation")))
+      .exitHereIfFailed
+    this
+  }
+
   //Realms
   def createRealm(): KeycloakScenarioBuilder = {
     chainBuilder = chainBuilder
@@ -313,8 +364,7 @@ class KeycloakScenarioBuilder {
         .header("Content-Type", "application/json")
         .body(StringBody("""{"id":"${createdRealmId}","realm":"${createdRealmId}","enabled": true}"""))
         .check(status.is(201))
-        .check(header("Location").notNull.saveAs("realmLocation")))
-      .exec(session => (session.removeAll("createdRealmId")))
+        .check(header("Location").notNull.saveAs("location")))
       .exitHereIfFailed
     this
   }
@@ -367,7 +417,7 @@ class KeycloakScenarioBuilder {
         .header("Content-Type", "application/json")
         .body(StringBody("{}"))
         .check(status.is(201))
-        .check(header("Location").notNull.saveAs("clientLocation")))
+        .check(header("Location").notNull.saveAs("location")))
       .exitHereIfFailed
     this
   }
@@ -386,10 +436,9 @@ class KeycloakScenarioBuilder {
   def deleteClient(): KeycloakScenarioBuilder = {
     chainBuilder = chainBuilder
       .exec(http("Delete client")
-        .delete("${clientLocation}")
+        .delete("${location}")
         .header("Authorization", "Bearer ${token}")
         .check(status.is(204)))
-      .exec(session => (session.removeAll("clientLocation")))
       .exitHereIfFailed
     this
   }

--- a/benchmark/src/main/scala/keycloak/scenario/admin/CreateGroups.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/CreateGroups.scala
@@ -1,0 +1,13 @@
+package keycloak.scenario.admin
+
+import keycloak.scenario.{CommonSimulation, KeycloakScenarioBuilder}
+
+
+class CreateGroups extends CommonSimulation {
+
+  setUp("Create and List Groups", new KeycloakScenarioBuilder()
+    .serviceAccountToken()
+    .listGroups()
+    .createGroups())
+
+}

--- a/benchmark/src/main/scala/keycloak/scenario/admin/CreateRoles.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/CreateRoles.scala
@@ -1,0 +1,13 @@
+package keycloak.scenario.admin
+
+import keycloak.scenario.{CommonSimulation, KeycloakScenarioBuilder}
+
+
+class CreateRoles extends CommonSimulation {
+
+  setUp("Create and List Roles", new KeycloakScenarioBuilder()
+    .serviceAccountToken()
+    .listRoles()
+    .createRoles())
+
+}


### PR DESCRIPTION
### Brief Description
Following the same pattern as CreateClients, I was looking to add the Roles and Groups related CRUD REST endpoints. 

### Implementation note
However, was hitting an issue with the current approach to be able to use the Service Account Enabled, client application. 

Even after adding all the possible roles from the Service Account Roles --> Client Roles --> realm-management under the  client, thats used in other scenarios, we are hitting a 403 Forbidden request error for listing and creating groups and roles, in its current shape.

----------

Closes #63