### PR TITLE
Add provision module to keycloak-benchmark

### DIFF
--- a/provision/docker-compose/PROVISION.md
+++ b/provision/docker-compose/PROVISION.md
@@ -1,0 +1,61 @@
+## Provision
+
+### docker-compose 
+
+>Note: This provisioning model only supports Keycloak Legacy distribution, we are working on a version to support Quarkus based distribution.
+
+#### Keycloak
+A light weight Keycloak server setup with, PostgreSQL DB as its external store using docker-compose.
+
+ - The image used for Keycloak server is the latest legacy container from [quay.io](https://quay.io/repository/keycloak/keycloak?tab=tags&tag=legacy)
+ 
+##### Pre-requisite
+The keycloak-legacy-postgres.yml file will work with the below docker and docker-compose versions
+
+- Docker CE : 20.10.12
+- Docker Compose: 1.29.2
+
+#### Bringing up the containers
+
+_Note: The below steps assume you are inside the `provision/docker-compose` directory from the root of this git repository._
+
+To run in a detached mode,
+
+```shell
+docker-compose -f keycloak/keycloak-legacy-postgres.yml up -d
+```
+
+- The Keycloak application will be available at http://localhost:8080/
+- The PostgreSQL db will be available at localhost:5432
+
+To view individual container logs,
+
+```shell
+docker-compose -f keycloak/keycloak-legacy-postgres.yml logs postgres
+```
+
+```shell
+docker-compose -f keycloak/keycloak-legacy-postgres.yml logs keycloak
+```
+
+_Note: To use the latest available version of the Keycloak image, run the command below when there is a new release of Keycloak available._
+
+```shell
+docker-compose pull
+```
+
+
+##### Deploying the dataset module custom provider to this containerized Keycloak distribution
+
+Assuming you have already built the [Dataset Module Readme](../README.md)
+
+```shell
+docker cp ../../dataset/target/keycloak-benchmark-dataset-*.jar keycloak:/opt/jboss/keycloak/standalone/deployments/
+```
+
+This will be a hot deploy, so restart of the container is not necessary.
+We can confirm the deploy with a log similar to the below one, from the Keycloak server logs
+
+```shell
+08:28:15,630 INFO  [org.jboss.as.server] (DeploymentScanner-threads - 2) WFLYSRV0010: Deployed "keycloak-benchmark-dataset-0.7-SNAPSHOT.jar" (runtime-name : "keycloak-benchmark-dataset-0.7-SNAPSHOT.jar")
+```

--- a/provision/docker-compose/keycloak/keycloak-legacy-postgres.yml
+++ b/provision/docker-compose/keycloak/keycloak-legacy-postgres.yml
@@ -1,0 +1,34 @@
+version: '2.2'
+
+volumes:
+  postgres_data:
+      driver: local
+
+services:
+  postgres:
+      image: postgres
+      container_name: postgres
+      volumes:
+        - postgres_data:/var/lib/postgresql/data
+      environment:
+        POSTGRES_DB: keycloak
+        POSTGRES_USER: keycloak
+        POSTGRES_PASSWORD: password
+      ports:
+        - "5432:5432"
+  keycloak:
+      image: quay.io/keycloak/keycloak:legacy
+      container_name: keycloak
+      environment:
+        DB_VENDOR: POSTGRES
+        DB_ADDR: postgres
+        DB_DATABASE: keycloak
+        DB_USER: keycloak
+        DB_SCHEMA: public
+        DB_PASSWORD: password
+        KEYCLOAK_USER: admin
+        KEYCLOAK_PASSWORD: admin
+      ports:
+        - 8080:8080
+      depends_on:
+        - postgres


### PR DESCRIPTION
### Brief Description
Using docker and docker-compose add a starter docker-compose.yml to be able to bring up keycloak server and postgres db containers.

#### Implementation note
The distribution used is a wildfly legacy server application and old store configurations are in place. In addition to that we have used cpusets within the docker-compose definitions to control the cpu quota allocated to the services within these containers. 

note: In future, we would like to add another setup for newer Quarkus based keycloak distribution and new store, both together or as separate definitions. 

#### Documentation note
This PR also includes the steps to deploy the  custom provider to the containerized Keycloak server and have the possibility to create seed data efficiently.

-----------
Closes #66