### PR TITLE
Add a bash utility to automate the service account enabled client management steps

### DIFF
--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -53,6 +53,7 @@ Some scenarios require a service account with the clientId `gatling`:
 Instead of following the above manual steps, you can use this [manage_gatling_client](manage_gatling_client.sh) script to do the setup for you.
 
 Login to the Keycloak server using the kcadm cli script, which comes with any Keycloak distribution
+
 ```shell
 $KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8081/auth --realm master --user admin --password admin
 ```

--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -61,13 +61,13 @@ $KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8081/au
 and then run this, for creating the needed realm and client
 
 ```shell
-./manage_gatling_client.sh -s http://localhost:8081/auth
+./manage_gatling_client.sh
 ```
 
 or run this, to recreate the realm and client for any reason
 
 ```shell
-./manage_gatling_client.sh -ds http://localhost:8081/auth
+./manage_gatling_client.sh -d
 ```
 
 

--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -43,14 +43,32 @@ Some scenarios require a service account with the clientId `gatling`:
 | CreateClient             | manage-clients, view-users |
 | CreateDeleteClient       | manage-clients, view-users |
 | CrawlUsers               | manage-clients, view-users |
-| CreateClientScope        | manage-clients, view-users |
-| CreateDeleteClientScope  | manage-clients, view-users |
 | CreateRole               |        manage-realm        |
 | CreateDeleteRole         |        manage-realm        |
 | CreateClientScope        | manage-clients, view-users |
 | CreateDeleteClientScope  | manage-clients, view-users |
 | CreateGroup              |        manage-users        |
 | CreateDeleteGroup        |        manage-users        |
+
+Instead of following the above manual steps, you can use this [manage_gatling_client](manage_gatling_client.sh) script to do the setup for you.
+
+Login to the Keycloak server using the kcadm cli script, which comes with any Keycloak distribution
+```shell
+$KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8081/auth --realm master --user admin --password admin
+```
+
+and then run this, for creating the needed realm and client
+
+```shell
+./manage_gatling_client.sh -s http://localhost:8081/auth
+```
+
+or run this, to recreate the realm and client for any reason
+
+```shell
+./manage_gatling_client.sh -ds http://localhost:8081/auth
+```
+
 
 
 #### Scenarios `keycloak.scenario.admin.CreateRealms` and `keycloak.scenario.admin.CreateDeleteRealms`

--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -61,7 +61,7 @@ $KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8081/au
 and then run this, for creating the needed realm and client
 
 ```shell
-./manage_gatling_client.sh
+./manage_gatling_client.sh -c gatling
 ```
 
 or run this, to recreate the realm and client for any reason

--- a/benchmark/manage_gatling_client.sh
+++ b/benchmark/manage_gatling_client.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+#Functions
+function usage {
+  echo "Usage: $(basename $0) -k KEYCLOAK_HOME -r REALM_NAME -c CLIENT_ID -s SERVER_URL [-d]" 2>&1
+  echo '-k keycloak home path ex: /home/opt/keycloak-18.0.0 '
+  echo '-r realm : default value realm-0'
+  echo '-c service account enabled client name : default value gatling'
+  echo '-s keycloak host server url : default value http://localhost:8081/auth'
+  echo '-d delete the client and realm : default value is false'
+  exit 1
+}
+
+function install_kcb {
+  echo "Installing kcadm.sh"
+  export PATH=$PATH:$KEYCLOAK_HOME/bin
+}
+
+function create_realm {
+  if kcadm.sh get realms  | grep \"realm\" | grep -q $REALM_NAME; then
+    echo "INFO: Skipping Realm creation as realm exists"
+  else
+    echo "INFO: Creating Realm with realm id : ${REALM_NAME}"
+    kcadm.sh create realms -s realm=$REALM_NAME -s enabled=true -o
+  fi
+}
+
+function create_client_assign_roles {
+  #Create the client application with Service Account Roles setup
+  CID=$(kcadm.sh create clients -r $REALM_NAME -s clientId=$CLIENT_ID -s enabled=true -i)
+  echo "INFO: Created New ${CLIENT_ID} Client with Client ID ${CID}"
+  #Update the client with necessary attributes
+  kcadm.sh update clients/$CID -r $REALM_NAME  -s "secret=4CYUuDEYvvAkjIcjcB0EgAJxmbXdgMYR" -s serviceAccountsEnabled=true  -s publicClient=false -s 'redirectUris=["http://localhost:8081"]'
+  kcadm.sh get clients/$CID -r $REALM_NAME --fields clientId,id,redirectUris,publicClient,serviceAccountsEnabled,secret
+
+  #Verify if the service account user exists
+  kcadm.sh get users -r $REALM_NAME -q username=service-account-$CLIENT_ID --fields id,username,enabled
+
+  #Assign the necessary Service Account based roles to the client
+  kcadm.sh add-roles -r $REALM_NAME --uusername service-account-$CLIENT_ID --cclientid realm-management --rolename manage-clients --rolename view-users --rolename manage-realm --rolename manage-users
+  #kcadm.sh get-roles -r $REALM_NAME --uusername service-account-$CLIENT_ID --cclientid realm-management
+}
+
+function delete_entities {
+  CID=$(kcadm.sh get clients -r realm-0 --fields id,clientId | grep gatling -B 1 | grep id | cut -d ":" -f 2 | sed -e 's/,//g' | sed -e 's/"//g' | sed -e 's/ //g')
+  echo "$CID"
+  kcadm.sh delete clients/$CID -r $REALM_NAME
+  kcadm.sh delete realms/$REALM_NAME
+}
+
+#main()
+#setting default values
+OPTIND=1
+REALM_NAME=realm-0
+CLIENT_ID=gatling
+SERVER_URL="http://localhost:8081/auth"
+DELETE_ENTITIES='false'
+
+while getopts ":skrcd:" arg; do
+  case $arg in
+    s) SERVER_URL="$OPTARG";
+        ;;
+    k) KEYCLOAK_HOME="$OPTARG";
+        ;;
+    r) REALM_NAME="$OPTARG";
+        ;;
+    c) CLIENT_ID="$OPTARG";
+        ;;
+    d) DELETE_ENTITIES="$OPTARG"; DELETE_ENTITIES='true'; 
+        ;;
+    \?) echo "ERROR: Invalid option: -${OPTARG}" >&2
+        usage
+        ;;
+  esac
+done
+
+#Handle missing opt args
+if (( ${OPTIND} == 1 ))
+then
+  echo "ERROR: No Options Specified"
+  usage
+fi
+shift $(( OPTIND -1 ))
+
+#Setup the KCB client tool in the system PATH
+install_kcb
+
+#Create or Re-Create Client and Realm
+if ${DELETE_ENTITIES}; then
+ echo "INFO: deleting the Client and Realm"
+ delete_entities
+else
+ echo "WARN: not deleting the Client and Realm"
+fi
+
+create_realm
+create_client_assign_roles

--- a/benchmark/manage_gatling_client.sh
+++ b/benchmark/manage_gatling_client.sh
@@ -61,7 +61,7 @@ while getopts "k:r:c:d" arg; do
         ;;
     c) CLIENT_ID="$OPTARG";
         ;;
-    d) DELETE_ENTITIES="$OPTARG";
+    d) DELETE_ENTITIES=true;
         ;;
     \?) echo "ERROR: Invalid option: -${OPTARG}" >&2
         usage

--- a/benchmark/manage_gatling_client.sh
+++ b/benchmark/manage_gatling_client.sh
@@ -24,7 +24,7 @@ function create_realm {
   if kcadm.sh get realms/${REALM_NAME} | grep -q ${REALM_NAME}; then
     echo -e "INFO: Skipping Realm creation as realm exists\n"
   else
-    echo -e "INFO: Creating Realm with realm id: ${REALM_NAME}\n"
+    echo -e "INFO: Creating Realm with realm id: ${REALM_NAME}"
     kcadm.sh create realms -s realm=$REALM_NAME -s enabled=true -o > /dev/null
   fi
 }
@@ -53,7 +53,7 @@ REALM_NAME=realm-0
 CLIENT_ID=gatling
 DELETE_ENTITIES='false'
 
-while getopts "k:r:c:d:" arg; do
+while getopts "k:r:c:d" arg; do
   case $arg in
     k) KEYCLOAK_HOME="$OPTARG";
         ;;

--- a/benchmark/manage_gatling_client.sh
+++ b/benchmark/manage_gatling_client.sh
@@ -2,29 +2,30 @@
 set -e
 set -o pipefail
 # set -x
+
 #Functions
 function usage {
   echo "Setup of test clients for the benchmark test with a pre-defined secret"
-  echo "Usage: $(basename $0) -k KEYCLOAK_HOME -r REALM_NAME -c CLIENT_ID -s SERVER_URL [-d]" 2>&1
+  echo "Usage: $(basename $0) -k KEYCLOAK_HOME -r REALM_NAME -c CLIENT_ID [-d]" 2>&1
   echo '-k keycloak home path ex: /home/opt/keycloak-18.0.0 : default value KEYCLOAK_HOME env variable'
+  echo '-d delete the client and realm before re-creating them: default value is false'
   echo '-r realm : default value realm-0'
   echo '-c service account enabled client name : default value gatling'
-  echo '-s keycloak host server url : default value http://localhost:8081/auth'
-  echo '-d delete the client and realm before re-creating them: default value is false'
+  echo '-d delete the client and realm : default value is false'
   exit 1
 }
 
-function install_kcb {
-  echo "Installing kcadm.sh"
+function set_kcb_in_path {
+  echo -e "Setting up kcadm.sh in PATH\n"
   export PATH=$PATH:$KEYCLOAK_HOME/bin
 }
 
 function create_realm {
-  if kcadm.sh get realms/${REALM_NAME}; then
-    echo "INFO: Skipping Realm creation as realm exists"
+  if kcadm.sh get realms/${REALM_NAME} | grep -q ${REALM_NAME}; then
+    echo -e "INFO: Skipping Realm creation as realm exists\n"
   else
-    echo "INFO: Creating Realm with realm id: ${REALM_NAME}"
-    kcadm.sh create realms -s realm=$REALM_NAME -s enabled=true -o
+    echo -e "INFO: Creating Realm with realm id: ${REALM_NAME}\n"
+    kcadm.sh create realms -s realm=$REALM_NAME -s enabled=true -o > /dev/null
   fi
 }
 
@@ -34,19 +35,14 @@ function create_client_assign_roles {
   echo "INFO: Created New ${CLIENT_ID} Client with Client ID ${CID}"
   #Update the client with necessary attributes
   kcadm.sh update clients/$CID -r $REALM_NAME  -s "secret=setup-for-benchmark" -s serviceAccountsEnabled=true  -s publicClient=false -s 'redirectUris=["http://localhost:8081"]'
-  kcadm.sh get clients/$CID -r $REALM_NAME --fields clientId,id,redirectUris,publicClient,serviceAccountsEnabled,secret
-
-  #Verify if the service account user exists
-  kcadm.sh get users -r $REALM_NAME -q username=service-account-$CLIENT_ID --fields id,username,enabled
-
   #Assign the necessary Service Account based roles to the client
   kcadm.sh add-roles -r $REALM_NAME --uusername service-account-$CLIENT_ID --cclientid realm-management --rolename manage-clients --rolename view-users --rolename manage-realm --rolename manage-users
-  #kcadm.sh get-roles -r $REALM_NAME --uusername service-account-$CLIENT_ID --cclientid realm-management
 }
 
 function delete_entities {
-  if kcadm.sh get realms/${REALM_NAME}; then
-    kcadm.sh delete realms/${REALM_NAME}
+  if kcadm.sh get realms/${REALM_NAME} | grep -q ${REALM_NAME}; then
+    kcadm.sh delete realms/${REALM_NAME} > /dev/null
+    echo -e "Successfully Deleted the Client and Realm\n"
   fi
 }
 
@@ -55,13 +51,10 @@ function delete_entities {
 OPTIND=1
 REALM_NAME=realm-0
 CLIENT_ID=gatling
-SERVER_URL="http://localhost:8081/auth"
 DELETE_ENTITIES='false'
 
-while getopts "s:k:r:c:d:" arg; do
+while getopts "k:r:c:d:" arg; do
   case $arg in
-    s) SERVER_URL="$OPTARG";
-        ;;
     k) KEYCLOAK_HOME="$OPTARG";
         ;;
     r) REALM_NAME="$OPTARG";
@@ -79,13 +72,13 @@ done
 #Handle missing opt args
 if (( ${OPTIND} == 1 ))
 then
-  echo "ERROR: No Options Specified"
+  echo -e "ERROR: No Options Specified\n"
   usage
 fi
 shift $(( OPTIND -1 ))
 
 #Setup the KCB client tool in the system PATH
-install_kcb
+set_kcb_in_path
 
 #Create or Re-Create Client and Realm
 if ${DELETE_ENTITIES}; then


### PR DESCRIPTION
Implementation details:

A simple bash utility which consumes the kcadm.sh CLI script bundled with the Keycloak distributions. 

Documentation note:
Detailed instructions are update in the README for the benchmark module

Closes #75