### PR TITLE
Join group test scenario.

### DIFF
--- a/benchmark/src/main/java/org/keycloak/benchmark/Config.java
+++ b/benchmark/src/main/java/org/keycloak/benchmark/Config.java
@@ -141,6 +141,11 @@ public class Config {
      */
     public static final int userNumberOfPages = Integer.getInteger("user-number-of-pages", 10);
 
+    // join-group-scenario properties
+    /**
+     * The group name used to find a group and determine which group the user should join.
+     */
+    public static final String joinGroup_groupName = System.getProperty("join-group-group-name");
 
     static {
         // if KEYCLOAK_SERVER_URIS env var is set, and system property serverUris is not set

--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -364,7 +364,7 @@ class KeycloakScenarioBuilder {
         .post(ADMIN_ENDPOINT + "/users")
         .header("Authorization", "Bearer ${token}")
         .header("Content-Type", "application/json")
-        .body(StringBody("""{"username":"joinGroup-${username}"}"""))
+        .body(StringBody("""{"username":"${username}"}"""))
         .check(status.is(201))
         .check(header("Location").notNull.saveAs("user-location")))
       .exitHereIfFailed

--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -357,6 +357,44 @@ class KeycloakScenarioBuilder {
     this
   }
 
+  def createUser(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .feed(Iterator.continually(Map("username" -> randomUUID())))
+      .exec(http("Create user")
+        .post(ADMIN_ENDPOINT + "/users")
+        .header("Authorization", "Bearer ${token}")
+        .header("Content-Type", "application/json")
+        .body(StringBody("""{"username":"joinGroup-${username}"}"""))
+        .check(status.is(201))
+        .check(header("Location").notNull.saveAs("user-location")))
+      .exitHereIfFailed
+    this
+  }
+
+  def joinGroup(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .exec(http("Join group")
+        .put("${user-location}/groups/${group-id}")
+        .header("Authorization", "Bearer ${token}")
+        .check(status.is(204)))
+      .exitHereIfFailed
+    this
+  }
+
+  def findGroup(groupName: String): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+        .exec(http("Find group")
+          .get(ADMIN_ENDPOINT + "/groups")
+          .header("Authorization", "Bearer ${token}")
+          .header("Accept-Encoding", "application/json")
+          .queryParam("search", groupName)
+          .queryParam("max", "1")
+          .check(status.is(200))
+          .check(jsonPath("$[0].id").notNull.saveAs("group-id")))
+      .exitHereIfFailed
+    this
+  }
+
   def needTokenRefresh(sess: Session): Boolean = {
     val lastRefresh = sess("accessTokenRefreshTime").as[Long]
 

--- a/benchmark/src/main/scala/keycloak/scenario/admin/JoinGroup.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/JoinGroup.scala
@@ -1,0 +1,15 @@
+package keycloak.scenario.admin
+
+import keycloak.scenario.{CommonSimulation, KeycloakScenarioBuilder}
+import org.keycloak.benchmark.Config
+
+class JoinGroup extends CommonSimulation {
+
+  private val groupName = Config.joinGroup_groupName
+
+  setUp("Join Group", new KeycloakScenarioBuilder()
+    .serviceAccountToken()
+    .createUser()
+    .findGroup(groupName)
+    .joinGroup());
+}


### PR DESCRIPTION
This scenario creates a new user, finds a given group and then adds the user to that group.
It can be used to check if group assignments still perform in reasonable time frames on systems with a lot of entities (especially groups and roles).