### PR TITLE
Add CREATE, DELETE, READ Operations for User Entity (closes #88)

### DIFF
--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -38,17 +38,19 @@ Some scenarios require a service account with the clientId `gatling`:
    * assign the roles, based on the below role-mapping table for the respective load simulation scenario
 * the client secret to be passed to the tests can be copied from the `Credentials` tab
 
-| Scenario Name            |       Assigned Roles       |
-|--------------------------|:--------------------------:|
-| CreateClient             | manage-clients, view-users |
-| CreateDeleteClient       | manage-clients, view-users |
-| CrawlUsers               | manage-clients, view-users |
-| CreateRole               |        manage-realm        |
-| CreateDeleteRole         |        manage-realm        |
-| CreateClientScope        | manage-clients, view-users |
-| CreateDeleteClientScope  | manage-clients, view-users |
-| CreateGroup              |        manage-users        |
-| CreateDeleteGroup        |        manage-users        |
+| Scenario Name           |       Assigned Roles       |
+|-------------------------|:--------------------------:|
+| CreateClient            | manage-clients, view-users |
+| CreateDeleteClient      | manage-clients, view-users |
+| CrawlUsers              | manage-clients, view-users |
+| CreateRole              |        manage-realm        |
+| CreateDeleteRole        |        manage-realm        |
+| CreateClientScope       | manage-clients, view-users |
+| CreateDeleteClientScope | manage-clients, view-users |
+| CreateGroup             |        manage-users        |
+| CreateDeleteGroup       |        manage-users        |
+| CreateUsers             |        manage-users        |
+| CreateDeleteUsers       |        manage-users        |
 
 Instead of following the above manual steps, you can use this [manage_gatling_client](manage_gatling_client.sh) script to do the setup for you.
 
@@ -114,13 +116,15 @@ These are the available test scenarios:
 * `keycloak.scenario.authentication.AuthorizationCode`: Authorization Code Grant Type
 * `keycloak.scenario.authentication.LoginUserPassword`: Browser Login (only Authorization Endpoint. After username+password login, there is no exchange of OAuth2 "code" for the tokens) 
 * `keycloak.scenario.authentication.ClientSecret`: Client Secret (Client Credentials Grant)
-* `keycloak.scenario.admin.CreateDeleteClient`: Create and deleted clients (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateDeleteClient`: Create and delete clients (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.CreateClient`: Create clients (requires `--client-secret=<client secret for gatling client>`)
-* `keycloak.scenario.admin.CreateDeleteRole`: Create and deleted roles (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateDeleteUsers`: Create and delete users (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateUsers`: Create users.. (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateDeleteRole`: Create and delete roles (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.CreateRole`: Create roles (requires `--client-secret=<client secret for gatling client>`)
-* `keycloak.scenario.admin.CreateDeleteGroup`: Create and deleted groups (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateDeleteGroup`: Create and delete groups (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.CreateGroup`: Create groups (requires `--client-secret=<client secret for gatling client>`)
-* `keycloak.scenario.admin.CreateDeleteClientScope`: Create and deleted client scopes (requires `--client-secret=<client secret for gatling client>`)
+* `keycloak.scenario.admin.CreateDeleteClientScope`: Create and delete client scopes (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.CreateClientScope`: Create client scope (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.UserCrawl`: Crawls all users page by page (requires `--client-secret=<client secret for gatling client>`)
 * `keycloak.scenario.admin.CreateRealm`: Create realms (requires `--admin-username=<admin login>` and `--admin-password=<admin password>`)

--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -555,7 +555,9 @@ class KeycloakScenarioBuilder {
             .header("Authorization", "Bearer ${token}")
             .queryParam("first", 0)
             .queryParam("max", 2)
-            .check(status.is(200)))
+            .check(
+              status.is(200),
+              jsonPath("$[*]").count.lte(2)))
           .exitHereIfFailed
     this
   }

--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -543,7 +543,30 @@ class KeycloakScenarioBuilder {
         .header("Content-Type", "application/json")
         .body(StringBody("""{"username":"${username}"}"""))
         .check(status.is(201))
-        .check(header("Location").notNull.saveAs("user-location")))
+        .check(header("Location").notNull.saveAs("userLocation")))
+      .exitHereIfFailed
+    this
+  }
+
+  def listUsers(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+          .exec(http("List Users")
+            .get(ADMIN_ENDPOINT + "/users")
+            .header("Authorization", "Bearer ${token}")
+            .queryParam("first", 0)
+            .queryParam("max", 2)
+            .check(status.is(200)))
+          .exitHereIfFailed
+    this
+  }
+
+  def deleteUser(): KeycloakScenarioBuilder = {
+    chainBuilder = chainBuilder
+      .exec(http("Delete User")
+        .delete("${userLocation}")
+        .header("Authorization", "Bearer ${token}")
+        .check(status.is(204)))
+      .exec(session => (session.removeAll("userLocation")))
       .exitHereIfFailed
     this
   }
@@ -551,7 +574,7 @@ class KeycloakScenarioBuilder {
   def joinGroup(): KeycloakScenarioBuilder = {
     chainBuilder = chainBuilder
       .exec(http("Join group")
-        .put("${user-location}/groups/${group-id}")
+        .put("${userLocation}/groups/${group-id}")
         .header("Authorization", "Bearer ${token}")
         .check(status.is(204)))
       .exitHereIfFailed

--- a/benchmark/src/main/scala/keycloak/scenario/admin/CreateDeleteUsers.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/CreateDeleteUsers.scala
@@ -1,0 +1,13 @@
+package keycloak.scenario.admin
+
+import keycloak.scenario.{CommonSimulation, KeycloakScenarioBuilder}
+
+class CreateDeleteUsers extends CommonSimulation {
+
+  setUp("Create, Read and Delete Users", new KeycloakScenarioBuilder()
+    .serviceAccountToken()
+    .createUser()
+    .listUsers()
+    .deleteUser()
+  );
+}

--- a/benchmark/src/main/scala/keycloak/scenario/admin/CreateUsers.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/admin/CreateUsers.scala
@@ -1,0 +1,13 @@
+package keycloak.scenario.admin
+
+import keycloak.scenario.{CommonSimulation, KeycloakScenarioBuilder}
+import org.keycloak.benchmark.Config
+
+class CreateUsers extends CommonSimulation {
+
+  setUp("Create, Read Users", new KeycloakScenarioBuilder()
+    .serviceAccountToken()
+    .createUser()
+    .listUsers()
+  );
+}


### PR DESCRIPTION
re-use and add new methods to support the create, read and delete operations for the User entity to test the new storage layer

closes #88 

The BENCHMARK.md has been updated to reflect the addition of the new entities