### PR TITLE
Upgrading OTEL agent, parsing traceIds and linking traces to logs

### DIFF
--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -38,7 +38,7 @@ spec:
               - /bin/bash
             args:
               - -c
-              - curl -L https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.14.0/opentelemetry-javaagent.jar -o /tmp/opentelemetry-javaagent.jar && /opt/keycloak/bin/kc.sh start --auto-build
+              - curl -L https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.15.0/opentelemetry-javaagent.jar -o /tmp/opentelemetry-javaagent.jar && /opt/keycloak/bin/kc.sh start --auto-build
 {{ end }}
             env:
 {{ if .Values.otel }}

--- a/provision/minikube/monitoring.yaml
+++ b/provision/minikube/monitoring.yaml
@@ -27,6 +27,7 @@ grafana:
       apiVersion: 1
       datasources:
       - name: Prometheus
+        uid: PBFA97CFB590B2093
         type: prometheus
         url: http://prometheus-kube-prometheus-prometheus.monitoring:9090/
         access: proxy
@@ -35,23 +36,44 @@ grafana:
         jsonData:
           timeInterval: 30s
       - name: Tempo
+        uid: P214B5B846CF3925F
         type: tempo
         url: http://tempo.monitoring.svc:3100/
         access: proxy
         isDefault: false
         editable: false
       - name: Jaeger
+        uid: PC9A941E8F2E49454
         type: jaeger
         url: "http://jaeger-query.monitoring.svc:16686"
         access: proxy
         isDefault: false
         editable: false
+        jsonData:
+          tracesToLogs:
+            datasourceUid: P8E80F9AEF21F6940
+            filterByTraceID: true,
+            mapTagNamesEnabled: true
+            mappedTags:
+              - key: "hostname"
+                value: "pod"
+            spanStartTimeShift: "-1h"
+            spanEndTimeShift: "1h"
       - name: Loki
+        uid: P8E80F9AEF21F6940
         type: loki
         url: "http://loki.monitoring.svc:3100"
         access: proxy
         isDefault: false
         editable: false
+        jsonData:
+          maxLines: 1000
+          derivedFields:
+            - datasourceUid: PC9A941E8F2E49454
+              matcherRegex: '"trace_id":"(\w*)"'
+              name: traceID
+              # url will be interpreted as query for the datasource
+              url: '$${__value.raw}'
 
 kube-state-metrics:
   namespaceOverride: monitoring

--- a/provision/minikube/promtail.yaml
+++ b/provision/minikube/promtail.yaml
@@ -14,6 +14,14 @@ config:
             - json:
                 expressions:
                   log_line: log
+            - json:
+                expressions:
+                  loggerName: loggerName
+                  level: level
+                source: log_line
+            - labels:
+                level: level
+                loggerName: loggerName
             - replace:
                 expression: "(.+)"
                 replace: "{{.log_line}}"

--- a/provision/minikube/upgrade.sh
+++ b/provision/minikube/upgrade.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+helm repo update
 
 kubectl create namespace monitoring || true
 helm upgrade --install prometheus prometheus-community/kube-prometheus-stack --set grafana."grafana\.ini".server.root_url=https://grafana.$(minikube ip).nip.io -f monitoring.yaml


### PR DESCRIPTION
With the latest OTEL 1.15 java agent release, the [JBoss JSON logger will log the trace IDs](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/6112). 

After upgrading and updating the configuration, the logs now link to the traces, traces link to the logs, and logs can be filtered by the trace id.

![log-trace-to-log](https://user-images.githubusercontent.com/3957921/174436593-72205f52-d667-404c-bf36-d05c82edad59.gif)
