### PR TITLE
Enable exemplars for Prometheus and Grafana timeseries diagrams.

### DIFF
--- a/provision/minikube/monitoring.yaml
+++ b/provision/minikube/monitoring.yaml
@@ -35,6 +35,9 @@ grafana:
         editable: false
         jsonData:
           timeInterval: 30s
+          exemplarTraceIdDestinations:
+            - datasourceUid: PC9A941E8F2E49454
+              name: trace_id
       - name: Tempo
         uid: P214B5B846CF3925F
         type: tempo
@@ -95,6 +98,8 @@ kubelet:
 
 prometheus:
   prometheusSpec:
+    enableFeatures:
+      - exemplar-storage
     podMonitorSelector: {}
     podMonitorSelectorNilUsesHelmValues: false
     ruleSelector: {}


### PR DESCRIPTION
Prometheus metrics can contain a trace ID for a metric that links to a recorded trace. More information are available in this blog post: https://vbehar.medium.com/using-prometheus-exemplars-to-jump-from-metrics-to-traces-in-grafana-249e721d4192

With the current open telemetry setup, this is available for the metric `http_server_duration_bucket`.

This commit enables this. 

An example query is: 

> histogram_quantile(0.95, sum(rate(http_server_duration_bucket [1m])) without (pod,http_host, http_flavor, job,endpoint, instance)) 

This works for timeseries diagrams when exemplars are enabled in the query:

(1) enable exemplars in the query
(2) hover with the mouse over an exemplar in the diagram, shown as a small rhombus
(3) click on the "Query with Jaeger" link to open a trace that matches the query

![image](https://user-images.githubusercontent.com/3957921/174447315-0863303f-b555-4d82-a014-81127afada21.png)

An overview with metrics with traces is visible via a curl on the open telemetry metrics endpoint: 

```
$ curl -H 'Accept: application/openmetrics-text; version=0.0.1' http://localhost:9464 -s -o - | grep trace
http_server_duration_bucket{http_flavor="1.1",http_host="keycloak.172.24.246.187.nip.io",http_method="GET",http_route="/realms/{realm}/protocol/{protocol}/auth",http_scheme="https",http_status_code="302",le="10.0"} 4.0 1655569010.552 # {span_id="e7f2669cf593eace",trace_id="72e4d047d06b6224a58efd03da0a8496"} 5.329096 1655563218.743
http_server_duration_bucket{http_flavor="1.1",http_host="keycloak.172.24.246.187.nip.io",http_method="GET",http_route="/admin/realms/{realm}/clients",http_scheme="https",http_status_code="200",le="5.0"} 2.0 1655569010.552 # {span_id="a03f6ea7607edaa1",trace_id="3b6c8cb711e4665815c8699d2cbfa6a7"} 4.541497 1655563226.876
http_server_duration_bucket{http_flavor="1.1",http_host="keycloak.172.24.246.187.nip.io",http_method="GET",http_route="/admin/realms/{realm}/clients",http_scheme="https",http_status_code="200",le="10.0"} 15.0 1655569010.552 # {span_id="8a6875f4907d77bb",trace_id="a219936d76a7978920068231286eb2aa"} 8.567495 1655563220.269
http_server_duration_bucket{http_flavor="1.1",http_host="keycloak.172.24.246.187.nip.io",http_method="GET",http_route="/admin/{realm}/console/whoami",http_scheme="https",http_status_code="200",le="5.0"} 3.0 1655569010.552 # {span_id="a2d96a480803b2b8",trace_id="23258ad3b3b8d0ef835e662069811599"} 2.834198 1655563225.767
http_server_duration_bucket{http_flavor="1.1",http_host="keycloak.172.24.246.187.nip.io",http_method="GET",http_route="/realms/{realm}/.well-known/{alias}",http_scheme="https",http_status_code="200",le="5.0"} 1.0 1655569010.552 # {span_id="6235988b85ced11b",trace_id="d438dcd8acd70b54ac6b0314cf040d13"} 3.74818 1655560426.603
[...]
```


