### PR TITLE
Adding Utility to create custom reports (fixes #100)

### DIFF
--- a/benchmark/BENCHMARK.md
+++ b/benchmark/BENCHMARK.md
@@ -107,7 +107,19 @@ You can set different options to change how tests should be executed. For a comp
 
 ### Report
 
-Check reports at the `result` directory.
+For the default gatling generated reports, check reports at the `result` directory.
+
+To generate a custom differential or trend line report from an existing repository of gatling simulations, you can use the [utility script](generate-custom-report.sh) based on [gatling-report](https://github.com/nuxeo/gatling-report/blob/master/README.md) project.
+
+Example Usage:
+```shell
+#for differential with custom template
+./generate-custom-report.sh -v 6.0 -s "~/JPAMapUndertow/simulation.log ~/HotRodUndertow/simulation.log" -d ~/reports/differential/templates -t src/main/resources/diff-v2.mustache
+
+#for trend lines with default template
+./generate-custom-report.sh -v 6.0 -s "~/JPAMapUndertow/simulation.log ~/HotRodUndertow/simulation.log ~/LegacyWildFly/simulation.log" -d ~/reports/trendLines/templates
+```
+
 
 ### Test Scenarios
 

--- a/benchmark/generate-custom-report.sh
+++ b/benchmark/generate-custom-report.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -e
+set -o pipefail
+# set -x
+
+#Functions
+function usage {
+  echo -e "Generate a CSV or HTML (differential or trendline) report from existing gatling simulation.log files \n"
+  echo -e "Usage: $(basename $0) -v GATLING_REPORT_VERSION -s SOURCE_DIR -t TARGET_DIR [-c] \nOptions:" 2>&1
+  echo -e '-v gatling-report release version to use \n refer here for latest versions https://maven-eu.nuxeo.org/nexus/#nexus-search;quick~gatling-report'
+  echo -e '-s source report path(s) where the simulation.log files are located,\nhint: provide the multiple locations in a double quotes'
+  echo '-d destination directory where the report would be stored'
+  echo '-t custom mustache template path'
+  echo '-c generate an csv report: default is to generate an HTML report'
+  exit 1
+}
+
+function pull_gatling_report_jar {
+  wget -q --no-directories --accept=jar https://maven-eu.nuxeo.org/nexus/service/local/repositories/vendor-releases/content/org/nuxeo/tools/gatling-report/${GATLING_REPORT_VERSION}/gatling-report-${GATLING_REPORT_VERSION}-capsule-fat.jar -O gatling-report-${GATLING_REPORT_VERSION}-fat.jar
+}
+
+function delete_gatling_report_jar {
+  rm gatling-report-${GATLING_REPORT_VERSION}-fat.jar
+}
+
+function generate_report {
+  if ${GENERATE_CSV_REPORT}; then
+    echo "GENERATING THE CSV REPORT"
+    java -jar gatling-report-${GATLING_REPORT_VERSION}-fat.jar $SRC_DIR > $TARGET_DIR/gatling-report-$(date +%s).csv
+  else
+    if ${USE_TEMPLATE}; then
+      echo "GENERATING THE HTML REPORT"
+      java -jar gatling-report-${GATLING_REPORT_VERSION}-fat.jar --template $TEMPLATE_PATH $SRC_DIR -o $TARGET_DIR -f  
+    else
+      echo "GENERATING THE HTML REPORT"
+      java -jar gatling-report-${GATLING_REPORT_VERSION}-fat.jar $SRC_DIR -o $TARGET_DIR -f
+    fi
+  fi
+}
+
+#main()
+#setting default values
+GATLING_REPORT_VERSION=6.0
+GENERATE_CSV_REPORT=false
+USE_TEMPLATE=false
+TARGET_DIR=/home/$USER/reports/
+
+while getopts "hv:s:d:t:c" arg; do
+  case $arg in
+    h) usage
+        ;;
+    v) GATLING_REPORT_VERSION="$OPTARG";
+        ;;
+    s) SRC_DIR="$OPTARG";
+        ;;
+    d) TARGET_DIR="$OPTARG";
+        ;;
+    t) TEMPLATE_PATH="$OPTARG";USE_TEMPLATE=true;
+        ;;
+    c) GENERATE_CSV_REPORT=true;
+        ;;
+    \?) echo "ERROR: Invalid option provided" >&2
+        usage
+        ;;
+  esac
+done
+
+#Handle missing opt args
+if (( ${OPTIND} == 1 ))
+then
+  echo -e "ERROR: No Options Specified\n"
+  usage
+fi
+shift $(( OPTIND -1 ))
+
+#call the functions
+pull_gatling_report_jar
+generate_report
+delete_gatling_report_jar

--- a/benchmark/generate-custom-report.sh
+++ b/benchmark/generate-custom-report.sh
@@ -6,12 +6,12 @@ set -o pipefail
 #Functions
 function usage {
   echo -e "Generate a CSV or HTML (differential or trendline) report from existing gatling simulation.log files \n"
-  echo -e "Usage: $(basename $0) -v GATLING_REPORT_VERSION -s SOURCE_DIR -t TARGET_DIR [-c] \nOptions:" 2>&1
-  echo -e '-v gatling-report release version to use \n refer here for latest versions https://maven-eu.nuxeo.org/nexus/#nexus-search;quick~gatling-report'
-  echo -e '-s source report path(s) where the simulation.log files are located,\nhint: provide the multiple locations in a double quotes'
-  echo '-d destination directory where the report would be stored'
+  echo -e "Usage: $(basename $0) -s SIMULATION_LOGS [-v GATLING_REPORT_VERSION] [-d TARGET_DIR] [-t TEMPLATE] [-c] \nOptions:" 2>&1
+  echo -e "-v gatling-report release version to use, default ${GATLING_REPORT_VERSION} \n   refer here for latest versions https://maven-eu.nuxeo.org/nexus/#nexus-search;quick~gatling-report"
+  echo -e '-s simulation.log files\n   hint: provide multiple locations in a double quotes'
+  echo "-d destination directory where the report would be stored, default ${TARGET_DIR}"
   echo '-t custom mustache template path'
-  echo '-c generate an csv report: default is to generate an HTML report'
+  echo '-c generate a csv report: default is to generate an HTML report'
   exit 1
 }
 

--- a/benchmark/src/main/resources/diff-v2.mustache
+++ b/benchmark/src/main/resources/diff-v2.mustache
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<head>
+  {{#scripts}}
+    <script src="{{.}}"></script>
+  {{/scripts}}
+  <style media="screen" type="text/css">
+    th {text-align:left}
+    td {text-align:right}
+    td.win {background-color: chartreuse;}
+    td.loose {background-color: darksalmon;}
+
+  </style>
+</head>
+
+<h1>{{ref.scenario}} Diff report</h1>
+<div id="summaryDiv">
+  <table id="summaryTab">
+    <tr>
+      <td></td>
+      <th>Reference</th>
+      <th>Challenger</th>
+      <th></th>
+    </tr>
+    <tr>
+      <th>Date</th>
+      <td>{{ref.simStat.startDate}}</td>
+      <td>{{challenger.simStat.startDate}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th>Simulation</th>
+      <td>{{ref.simStat.scenario}}</td>
+      <td>{{challenger.simStat.scenario}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th>Duration (s)</th>
+      <td>{{ref.simStat.duration}}</td>
+      <td>{{challenger.simStat.getDuration}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th>Throughput requests/s</th>
+      <td>{{ref.simStat.throughput}}</td>
+      <td>{{challenger.simStat.throughput}}</td>
+      <td class="{{rpsClass}}">{{rpsPercent}} %</td>
+    </tr>
+    <tr>
+      <th>Average response time ms</th>
+      <td>{{ref.simStat.average}}</td>
+      <td>{{challenger.simStat.average}}</td>
+      <td class="{{avgClass}}">{{avgPercent}} %</td>
+    </tr>
+    <tr>
+      <th>p50 response time ms</th>
+      <td>{{ref.simStat.p50}}</td>
+      <td>{{challenger.simStat.p50}}</td>
+    </tr>
+    <tr>
+      <th>p95 response time ms</th>
+      <td>{{ref.simStat.p95}}</td>
+      <td>{{challenger.simStat.p95}}</td>
+    </tr>
+    <tr>
+      <th>p99 response time ms</th>
+      <td>{{ref.simStat.p99}}</td>
+      <td>{{challenger.simStat.p99}}</td>
+    </tr>
+    <tr>
+      <th>Requests</th>
+      <td>{{ref.simStat.count}}</td>
+      <td>{{challenger.simStat.count}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th>Error(s)</th>
+      <td>{{ref.simStat.errorCount}}</td>
+      <td>{{challenger.simStat.errorCount}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th>Max concurrent users</th>
+      <td>{{ref.simStat.maxUsers}}</td>
+      <td>{{challenger.simStat.maxUsers}}</td>
+      <td></td>
+    </tr>
+  </table>
+</div>
+
+<div id="responseAllDiv"></div>
+{{#getDiffRequests}}
+  <div id="response{{refR.indice}}Div"></div>
+{{/getDiffRequests}}
+
+
+<div id="monitoring">
+  <table>
+    <tr>
+      <td>
+        {{#ref.simStat.graphite.images}}
+          <a class="image" href="{{url}}" title="{{title}}"><img src="{{filename}}" alt="{{title}}"/></a>
+        {{/ref.simStat.graphite.images}}
+      </td>
+      <td>
+        {{#challenger.simStat.graphite.images}}
+          <a class="image" href="{{url}}" title="{{title}}"><img src="{{filename}}" alt="{{title}}"/></a>
+        {{/challenger.simStat.graphite.images}}
+      </td>
+    </tr>
+  </table>
+</div>
+
+
+<script>
+
+var dataAll = [
+  {
+    y: {{ref.simStat.durations}},
+    name: 'Reference: {{ref.simStat.average}}ms',
+    boxpoints: {{{ref.simStat.boxpoints}}},
+    jitter: 0.3,
+    pointpos: -1.8,
+    boxmean: 'sd',
+    type: 'box',
+    marker:{
+      size:2,
+      opacity:0.6
+    }
+  },
+  {
+    y: {{challenger.simStat.durations}},
+    name: 'Challenger: {{challenger.simStat.average}}ms',
+    boxpoints: {{{challenger.simStat.boxpoints}}},
+    jitter: 0.3,
+    pointpos: -1.8,
+    boxmean: 'sd',
+    type: 'box',
+    marker:{
+      size:2,
+      opacity:0.6
+    }
+  }
+];
+var layoutAll = {
+  height: 500,
+  width: 900,
+  yaxis: {
+    title: 'Time ms',
+    type: 'log'
+  },
+  showlegend: true,
+  xaxis: {
+      showticklabels: false
+  },
+  title: 'Response time all requests'
+};
+Plotly.newPlot('responseAllDiv', dataAll, layoutAll);
+
+{{#getDiffRequests}}
+var data{{refR.indice}} = [
+  {
+    y: {{refR.durations}},
+    name: 'Reference: {{refR.average}}ms',
+    boxpoints: {{{refR.boxpoints}}},
+    jitter: 0.3,
+    pointpos: -1.8,
+    boxmean: 'sd',
+    type: 'box',
+    marker:{
+      size:2,
+      opacity:0.6
+    }
+  },
+  {
+    y: {{challengerR.durations}},
+    name: 'Challenger: {{challengerR.average}}ms',
+    boxpoints: {{{challengerR.boxpoints}}},
+    jitter: 0.3,
+    pointpos: -1.8,
+    boxmean: 'sd',
+    type: 'box',
+    marker:{
+      size:2,
+      opacity:0.6
+    }
+  }
+];
+var layout{{refR.indice}} = {
+  height: 500,
+  width: 900,
+  yaxis: {
+    title: 'Time ms',
+    type: 'log'
+  },
+  showlegend: true,
+  xaxis: {
+      showticklabels: false
+  },
+  title: '{{refR.request}}'
+};
+Plotly.newPlot('response{{refR.indice}}Div', data{{refR.indice}}, layout{{refR.indice}});
+{{/getDiffRequests}}
+
+
+</script>


### PR DESCRIPTION

### Implementation note:

- Utility downloads the needed binary. 
- Generates the report taking the source simulation logs and a target report directory and writes the HTML|CSV report there. 
- In the end, it removes the binaries. 
- The utility can also optionally consume a custom mustache template used to customize the reports, which is currently hosted under benchmark/src/main/resources.

Documentation note:
Updated the Report section of the benchmark/BENCHMARK.md with the new utility usage information.

Closes #100