### PR TITLE
Fix URL pattern for Quarkus distribution

### DIFF
--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -142,7 +142,7 @@ class KeycloakScenarioBuilder {
         .queryParam("scope", "openid profile")
         .check(status.is(200),
           regex("action=\"([^\"]*)\"").find.transform(_.replaceAll("&amp;", "&")).saveAs("login-form-uri"),
-          regex("href=\"/auth(/realms/[^\"]*/login-actions/registration[^\"]*)\"").find.transform(_.replaceAll("&amp;", "&")).saveAs("registration-link")))
+          regex("href=\"(/auth)?(/realms/[^\"]*/login-actions/registration[^\"]*)\"").find.transform(_.replaceAll("&amp;", "&")).saveAs("registration-link")))
       // if already logged in the check will fail with:
       // status.find.is(200), but actually found 302
       // The reason is that instead of returning the login page we are immediately redirected to the app that requested authentication


### PR DESCRIPTION
This makes the "/auth" prefix optional.

In order to test it with the minikube setup, I needed to manually:

* enable user self-registration in `realm-0`
* created a client "client-0" with a valid redirect URL - I chose "https://keycloak.xxx.xxx.xxx.xxx.nip.io/*" (replace with the the current IP address)
* created a "user-0" with a password "user-0-password"

I wonder if this could be automated more using dataset provider or the shell script or a mixture of both.

Closes #122