### PR TITLE
Add db connection pool values for initial, min, max and switch back to docker runtime (fixes #118)

### DIFF
--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -7,7 +7,10 @@ output: prefixed
 vars:
   IP:
     sh: minikube ip
-  KB_RETENTION: '{{default "60d" .KB_RETENTION}}'
+  KB_RETENTION: '{{default "7d" .KB_RETENTION}}'
+  KC_DB_POOL_INITIAL_SIZE: '{{default "5" .KC_DB_POOL_INITIAL_SIZE}}'
+  KC_DB_POOL_MAX_SIZE: '{{default "10" .KC_DB_POOL_MAX_SIZE}}'
+  KC_DB_POOL_MIN_SIZE: '{{default "5" .KC_DB_POOL_MIN_SIZE}}'
 
 dotenv: ['.env']
 
@@ -65,11 +68,17 @@ tasks:
       # create marker files that can then be checked in other tasks
       - mkdir -p .task
       - echo {{.KB_RETENTION}} > .task/var-KB_RETENTION
+      - echo {{.KC_DB_POOL_INITIAL_SIZE}} > .task/var-KC_DB_POOL_INITIAL_SIZE
+      - echo {{.KC_DB_POOL_MAX_SIZE}} > .task/var-KC_DB_POOL_MAX_SIZE
+      - echo {{.KC_DB_POOL_MIN_SIZE}} > .task/var-KC_DB_POOL_MIN_SIZE
     run: once
     sources:
       - .task/subtask-{{.TASK}}.yaml
     status:
       - test "{{.KB_RETENTION}}" == "$(cat .task/var-KB_RETENTION)"
+      - test "{{.KC_DB_POOL_INITIAL_SIZE}}" == "$(cat .task/var-KC_DB_POOL_INITIAL_SIZE)"
+      - test "{{.KC_DB_POOL_MAX_SIZE}}" == "$(cat .task/var-KC_DB_POOL_MAX_SIZE)"
+      - test "{{.KC_DB_POOL_MIN_SIZE}}" == "$(cat .task/var-KC_DB_POOL_MIN_SIZE)"
 
   prometheus:
     deps:
@@ -251,14 +260,22 @@ tasks:
       - loki
       - tempo
       - promtail
+      - env
     cmds:
       - kubectl create namespace keycloak || true
       - kubectl -n keycloak apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/nightly/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
       - kubectl -n keycloak apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/nightly/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
       - kubectl -n keycloak apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/nightly/kubernetes/kubernetes.yml
-      - helm upgrade --install keycloak --set hostname={{.IP}}.nip.io keycloak
+      - >
+        helm upgrade --install keycloak
+        --set hostname={{.IP}}.nip.io 
+        --set db-pool-initial-size={{.KC_DB_POOL_INITIAL_SIZE}}
+        --set db-pool-min-size={{.KC_DB_POOL_MIN_SIZE}}
+        --set db-pool-max-size={{.KC_DB_POOL_MAX_SIZE}}
+        keycloak
       - kubectl get deployment/postgres -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json
       - bash -c ./isup.sh
     sources:
       - keycloak/**/*.*
       - .task/subtask-{{.TASK}}.yaml
+      - .task/var-KC_DB_POOL*

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -12,6 +12,12 @@ spec:
       value: postgres
     - name: db-url
       value: jdbc:postgresql://postgres:5432/keycloak
+    - name: db-pool-min-size
+      value: {{ quote .Values.dbPoolInitialSize }}
+    - name: db-pool-max-size
+      value: {{ quote .Values.dbPoolMaxSize }}
+    - name: db-pool-initial-size
+      value: {{ quote .Values.dbPoolMinSize }}
     - name: log-console-output
       value: json
     - name: metrics-enabled

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -6,3 +6,6 @@ hostname: 172.30.97.253.nip.io
 monitoring: true
 otel: false
 cryostat: true
+dbPoolInitialSize: 5
+dbPoolMaxSize: 10
+dbPoolMinSize: 5

--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -12,8 +12,8 @@ if [ "$GITHUB_ACTIONS" == "" ]; then
     DRIVER=hyperv
   fi
   minikube config set driver ${DRIVER}
-  minikube config set container-runtime cri-o
-  minikube start --container-runtime=cri-o --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400"
+  minikube config set container-runtime docker
+  minikube start --container-runtime=docker --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400"
 fi
 minikube addons enable ingress
 echo -e "use\n\n  kubectl get pods -A -w\n\nto get information about starting pods\n\n"


### PR DESCRIPTION
### Details

Using the default values targetting a developer environment for db connection pool stats and the persistent storage retention period.

Switching the main line branch to use docker runtime, as we hit issues with cri-o runtime, we shall explore options to reduce the amount of metrics we are scraping. referece: #128

----

Closes #118 