### PR TITLE
Add a Keycloak Benchmark CI runner script, to execute simulations on a CI System (fixes #134)

### DIFF
--- a/kcb-ci-runner.sh
+++ b/kcb-ci-runner.sh
@@ -1,0 +1,80 @@
+#!/bin/bash 
+set -e
+
+export REPORTS_HOME=$USER_HOME/reports
+export MINIKUBE_HOME=$PROJECT_HOME/provision/minikube
+
+echo "INFO: reset the keycloak based on the parametrized input"
+export RESET_KEYCLOAK=${RESET_KEYCLOAK:-true}
+if $RESET_KEYCLOAK; then
+  cd $MINIKUBE_HOME
+  task reset-keycloak
+  echo "INFO: task reset-keycloak has been run"
+  cd $PROJECT_HOME
+else
+  echo "INFO: Keycloak DB is not reset for this run"
+fi
+
+echo "INFO: set environment variables with parametrized inputs or defaults"
+export GRAPHITE_TCP_ADDR=$(minikube ip)
+export KC_SERVER_URL=${KC_SERVER_URL:-"https://keycloak.$GRAPHITE_TCP_ADDR.nip.io/"}
+export SCENARIO=${SCENARIO}
+export CLIENT_SECRET=setup-for-benchmark
+export RAMPUP=${RAMPUP}
+export MEASUREMENT=${MEASUREMENT}
+export RAMPDOWN=${RAMPDOWN}
+export USER_THINK_TIME=${USER_THINK_TIME}
+export SLA_ERROR_PERCENTAGE=${SLA_ERROR_PERCENTAGE:-0}
+export SLA_MEAN_RESPONSE_TIME=${SLA_MEAN_RESPONSE_TIME:-400}
+
+export WORKLOAD_MODEL=${WORKLOAD_MODEL}
+if [ "$WORKLOAD_MODEL" = "open" ]; then 
+    export WORKLOAD_PARAM="--users-per-sec=$WORKLOAD_UNIT"
+elif [ "$WORKLOAD_MODEL" = "closed" ]; then 
+    export WORKLOAD_PARAM="--concurrent-users=$WORKLOAD_UNIT"
+else 
+    echo "Invalid WORKLOAD_MODEL: \"$WORKLOAD_MODEL\". Valid values: \"open\" or \"closed\"."
+    exit 1
+fi
+
+#pull latest project and build
+echo "Building '$KCB_REPOSITORY' branch 'main'"
+git diff
+git pull
+export KCB_REVISION=$(git rev-parse --short HEAD)
+echo "KCB_REVISION: $KCB_REVISION"
+mvn -f benchmark clean install -DskipTests
+KCB_ZIP=$(find benchmark -name keycloak-benchmark-*.zip)
+KCB_VERSION=$(echo $KCB_ZIP | sed -n "s/.*keycloak-benchmark-\(\S*\).zip$/\1/p")
+echo "KCB_VERSION: $KCB_VERSION"
+if [ -d "keycloak-benchmark-$KCB_VERSION" ]; then rm -rf "keycloak-benchmark-$KCB_VERSION"; fi
+echo "Unzipping"
+unzip -qo $KCB_ZIP
+
+KCB_HOME=$PROJECT_HOME/keycloak-benchmark-$KCB_VERSION
+cd $KCB_HOME
+
+#Remove old results before the run
+rm -rf results/; mkdir -p results/
+export RESULTS_HOME=$KCB_HOME/results
+export REPORT_DIR=$SCENARIO-$(date -u "+%Y-%m-%dT%H-%M-%S%Z")
+
+#Execute the keycloak benchmark and start simulation
+echo "INFO: Running kcb.sh --scenario=keycloak.scenario.$SCENARIO --server-url=$KC_SERVER_URL --client-secret=$CLIENT_SECRET $WORKLOAD_PARAM --ramp-up=$RAMPUP --measurement=$MEASUREMENT --ramp-down=$RAMPDOWN --user-think-time=$USER_THINK_TIME"
+
+./bin/kcb.sh --scenario=keycloak.scenario.$SCENARIO \
+--server-url=$KC_SERVER_URL --client-secret=$CLIENT_SECRET \
+$WORKLOAD_PARAM \
+--ramp-up=$RAMPUP --measurement=$MEASUREMENT \
+--ramp-down=$RAMPDOWN --user-think-time=$USER_THINK_TIME
+
+echo "INFO: Archive simulation.log and gatling HTML reports, for the run"
+cd $RESULTS_HOME
+mkdir -p $REPORTS_HOME/$REPORT_DIR/SimulationLogs
+zip -qr $REPORTS_HOME/$REPORT_DIR/$REPORT_DIR.zip . 
+cp $RESULTS_HOME/*/simulation.log $REPORTS_HOME/$REPORT_DIR/SimulationLogs
+
+#Generate Report
+cd $PROJECT_HOME/benchmark
+./generate-custom-report.sh -v 6.0 -s "$REPORTS_HOME/$REPORT_DIR/SimulationLogs/simulation.log" -d "$REPORTS_HOME/$REPORT_DIR/"
+echo "INFO: generated the report and it should be available at $REPORTS_HOME/$REPORT_DIR/"

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -7,7 +7,10 @@ output: prefixed
 vars:
   IP:
     sh: minikube ip
-  KB_RETENTION: '{{default "60d" .KB_RETENTION}}'
+  KB_RETENTION: '{{default "7d" .KB_RETENTION}}'
+  KC_DB_POOL_INITIAL_SIZE: '{{default "5" .KC_DB_POOL_INITIAL_SIZE}}'
+  KC_DB_POOL_MAX_SIZE: '{{default "10" .KC_DB_POOL_MAX_SIZE}}'
+  KC_DB_POOL_MIN_SIZE: '{{default "5" .KC_DB_POOL_MIN_SIZE}}'
 
 dotenv: ['.env']
 
@@ -65,11 +68,17 @@ tasks:
       # create marker files that can then be checked in other tasks
       - mkdir -p .task
       - echo {{.KB_RETENTION}} > .task/var-KB_RETENTION
+      - echo {{.KC_DB_POOL_INITIAL_SIZE}} > .task/var-KC_DB_POOL_INITIAL_SIZE
+      - echo {{.KC_DB_POOL_MAX_SIZE}} > .task/var-KC_DB_POOL_MAX_SIZE
+      - echo {{.KC_DB_POOL_MIN_SIZE}} > .task/var-KC_DB_POOL_MIN_SIZE
     run: once
     sources:
       - .task/subtask-{{.TASK}}.yaml
     status:
       - test "{{.KB_RETENTION}}" == "$(cat .task/var-KB_RETENTION)"
+      - test "{{.KC_DB_POOL_INITIAL_SIZE}}" == "$(cat .task/var-KC_DB_POOL_INITIAL_SIZE)"
+      - test "{{.KC_DB_POOL_MAX_SIZE}}" == "$(cat .task/var-KC_DB_POOL_MAX_SIZE)"
+      - test "{{.KC_DB_POOL_MIN_SIZE}}" == "$(cat .task/var-KC_DB_POOL_MIN_SIZE)"
 
   prometheus:
     deps:
@@ -251,14 +260,22 @@ tasks:
       - loki
       - tempo
       - promtail
+      - env
     cmds:
       - kubectl create namespace keycloak || true
       - kubectl -n keycloak apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/nightly/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
       - kubectl -n keycloak apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/nightly/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
       - kubectl -n keycloak apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/nightly/kubernetes/kubernetes.yml
-      - helm upgrade --install keycloak --set hostname={{.IP}}.nip.io keycloak
+      - >
+        helm upgrade --install keycloak
+        --set hostname={{.IP}}.nip.io 
+        --set db-pool-initial-size={{.KC_DB_POOL_INITIAL_SIZE}}
+        --set db-pool-min-size={{.KC_DB_POOL_MIN_SIZE}}
+        --set db-pool-max-size={{.KC_DB_POOL_MAX_SIZE}}
+        keycloak
       - kubectl get deployment/postgres -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json
       - bash -c ./isup.sh
     sources:
       - keycloak/**/*.*
       - .task/subtask-{{.TASK}}.yaml
+      - .task/var-KC_DB_POOL*

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -12,6 +12,12 @@ spec:
       value: postgres
     - name: db-url
       value: jdbc:postgresql://postgres:5432/keycloak
+    - name: db-pool-min-size
+      value: {{ quote .Values.dbPoolInitialSize }}
+    - name: db-pool-max-size
+      value: {{ quote .Values.dbPoolMaxSize }}
+    - name: db-pool-initial-size
+      value: {{ quote .Values.dbPoolMinSize }}
     - name: log-console-output
       value: json
     - name: metrics-enabled

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -6,3 +6,6 @@ hostname: 172.30.97.253.nip.io
 monitoring: true
 otel: false
 cryostat: true
+dbPoolInitialSize: 5
+dbPoolMaxSize: 10
+dbPoolMinSize: 5

--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -12,8 +12,8 @@ if [ "$GITHUB_ACTIONS" == "" ]; then
     DRIVER=hyperv
   fi
   minikube config set driver ${DRIVER}
-  minikube config set container-runtime cri-o
-  minikube start --container-runtime=cri-o --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400"
+  minikube config set container-runtime docker
+  minikube start --container-runtime=docker --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400"
 fi
 minikube addons enable ingress
 echo -e "use\n\n  kubectl get pods -A -w\n\nto get information about starting pods\n\n"


### PR DESCRIPTION

This script assumes, it will intake certain environment and parametrized variables coming in from a CI system job (ex. Jenkins)

The script automates a bunch of actions needed, such as

  - Reset the Keycloak K8s setup using minikube

  - SET all the needed environment variables and configurations for the simulation and execute the simulation

  - Archive the Gatling results, create the custom report and store all the Archived resutls, reports in a central location

------

Closes (#134)