### PR TITLE
Adding the storage option to the provisioning

### DIFF
--- a/provision/minikube/README.adoc
+++ b/provision/minikube/README.adoc
@@ -313,6 +313,8 @@ All tasks are described in the `Taskfile.yaml` file.
 If one of the commands in a task fails, the whole task will fail.
 If there are parallel tasks running and one of the tasks fails, _task_ will kill the other tasks running in parallel.
 
+For environment-specific settings, add a `.env` file with the contents necessary for your environment.
+
 The following list shows some command line examples:
 
 `task`::
@@ -324,10 +326,14 @@ Executes the `default` task, but execute all tasks event if no source file has b
 Run it after minikube has been re-created.
 
 `task <taskname>`::
-Execute a specific from the `Taskfile.yaml`.
+Execute a specific task from the `Taskfile.yaml`.
 Most tasks are set up to run only when modified, so task might reply with `task: Task "<taskname>" is up to date`.
 To force execution of a task, add the `-f` flag.
 This will then execute both the task and its dependencies.
+
+`task <var>=<value>`::
+Set a variable with a specific value, then run the task.
+Use it for example to set the storage type in a one-off run: `task KC_STORAGE=jpa`.
 
 `task --dry`::
 Show which tasks would be executed.

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -11,6 +11,7 @@ vars:
   KC_DB_POOL_INITIAL_SIZE: '{{default "5" .KC_DB_POOL_INITIAL_SIZE}}'
   KC_DB_POOL_MAX_SIZE: '{{default "10" .KC_DB_POOL_MAX_SIZE}}'
   KC_DB_POOL_MIN_SIZE: '{{default "5" .KC_DB_POOL_MIN_SIZE}}'
+  KC_STORAGE: '{{default "" .KC_STORAGE}}'
 
 dotenv: ['.env']
 
@@ -46,6 +47,7 @@ tasks:
     cmds:
       - bash -c "kubectl delete deployment/postgres -n keycloak || exit 0"
       - bash -c "kubectl delete keycloak/keycloak -n keycloak || exit 0"
+      - bash -c "kubectl delete deployment/keycloak-operator -n keycloak || exit 0"
       # discard status of keycloak to force redeployment
       - rm -f .task/checksum/keycloak
       # discard status of gatling user to force redeployment
@@ -71,6 +73,7 @@ tasks:
       - echo {{.KC_DB_POOL_INITIAL_SIZE}} > .task/var-KC_DB_POOL_INITIAL_SIZE
       - echo {{.KC_DB_POOL_MAX_SIZE}} > .task/var-KC_DB_POOL_MAX_SIZE
       - echo {{.KC_DB_POOL_MIN_SIZE}} > .task/var-KC_DB_POOL_MIN_SIZE
+      - echo {{.KC_STORAGE}} > .task/var-KC_STORAGE
     run: once
     sources:
       - .task/subtask-{{.TASK}}.yaml
@@ -79,6 +82,7 @@ tasks:
       - test "{{.KC_DB_POOL_INITIAL_SIZE}}" == "$(cat .task/var-KC_DB_POOL_INITIAL_SIZE)"
       - test "{{.KC_DB_POOL_MAX_SIZE}}" == "$(cat .task/var-KC_DB_POOL_MAX_SIZE)"
       - test "{{.KC_DB_POOL_MIN_SIZE}}" == "$(cat .task/var-KC_DB_POOL_MIN_SIZE)"
+      - test "{{.KC_STORAGE}}" == "$(cat .task/var-KC_STORAGE)"
 
   prometheus:
     deps:
@@ -249,6 +253,7 @@ tasks:
       - .task/subtask-{{.TASK}}.yaml
       # if keycloak's database deployment changes, this will restart the DB and the Gatling user needs to be re-created
       - .task/status-keycloak-db.json
+      - .task/var-KC_STORAGE
 
   keycloak:
     deps:
@@ -272,10 +277,11 @@ tasks:
         --set db-pool-initial-size={{.KC_DB_POOL_INITIAL_SIZE}}
         --set db-pool-min-size={{.KC_DB_POOL_MIN_SIZE}}
         --set db-pool-max-size={{.KC_DB_POOL_MAX_SIZE}}
+        --set storage={{.KC_STORAGE}}
         keycloak
       - kubectl get deployment/postgres -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json
       - bash -c ./isup.sh
     sources:
       - keycloak/**/*.*
       - .task/subtask-{{.TASK}}.yaml
-      - .task/var-KC_DB_POOL*
+      - .task/var-KC_*

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -18,6 +18,10 @@ spec:
       value: {{ quote .Values.dbPoolMaxSize }}
     - name: db-pool-initial-size
       value: {{ quote .Values.dbPoolMinSize }}
+{{ if ne .Values.storage "" }}
+    - name: storage
+      value: {{ quote .Values.storage }}
+{{ end }}
     - name: log-console-output
       value: json
     - name: metrics-enabled

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -9,3 +9,4 @@ cryostat: true
 dbPoolInitialSize: 5
 dbPoolMaxSize: 10
 dbPoolMinSize: 5
+storage:


### PR DESCRIPTION
Closes #138

The provisioning of Keycloak will succeed, but then fail with an error when setting up the Gatling client: https://github.com/keycloak/keycloak/issues/13200

I assume that this PR can be reviewed and merged regardless, as it looks independent to the Keycloak issue. 

To run the provisioning with a given storage option, execute

```
task KC_STORAGE=jpa
```

Another supported value is `chm` for concurrent hashmap. Eventually we would also run tests for that. As of tomorrow the nightly build will contain also the user-session storage. 