### PR TITLE
Add Infinispan to minikube setup

### DIFF
--- a/provision/minikube/keycloak/templates/NOTES.txt
+++ b/provision/minikube/keycloak/templates/NOTES.txt
@@ -12,6 +12,11 @@ Connect to PostgreSQL on {{ .Values.hostname }}:30009
   user: keycloak
   password: pass
   JDBC URL: jdbc:postgresql://{{ .Values.hostname }}:30009/keycloak
+{{ else if eq .Values.database "infinispan" -}}
+Connect to Infinispan on {{ .Values.hostname }}:30011
+  user: admin
+  password: admin
+  Console URL: https://infinispan.{{ .Values.hostname }}/
 {{ else -}}
 Connect to CockroachDB on {{ .Values.hostname }}:30010
   user: keycloak

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-deployment.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-deployment.yaml
@@ -1,0 +1,53 @@
+{{ if eq .Values.database "infinispan" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: infinispan
+  name: infinispan
+  namespace: {{ .Values.namespace }}
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: infinispan
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: infinispan
+    spec:
+      containers:
+        - image: quay.io/infinispan/server:12.1.7.Final
+          env:
+            - name: USER
+              value: admin
+            - name: PASS
+              value: admin
+          imagePullPolicy: Always
+          startupProbe:
+            tcpSocket:
+              port: 11222
+            failureThreshold: 20
+            initialDelaySeconds: 10
+            periodSeconds: 2
+          readinessProbe:
+            tcpSocket:
+              port: 11222
+            failureThreshold: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 11222
+            failureThreshold: 10
+            periodSeconds: 10
+          name: infinispan
+          ports:
+            - containerPort: 11222
+              protocol: TCP
+      restartPolicy: Always
+{{ end }}

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-ingress.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-ingress.yaml
@@ -1,0 +1,26 @@
+{{ if eq .Values.database "infinispan" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: infinispan
+  name: infinispan
+  namespace: keycloak
+spec:
+  defaultBackend:
+    service:
+      name: infinispan
+      port:
+        number: 11222
+  rules:
+    - host: infinispan.{{ .Values.hostname }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: infinispan
+                port:
+                  number: 11222
+            path: /
+            pathType: ImplementationSpecific
+{{end}}

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
@@ -1,0 +1,17 @@
+{{ if eq .Values.database "infinispan" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: infinispan-nodeport
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: infinispan
+spec:
+  type: NodePort
+  ports:
+    - protocol: TCP
+      port: 11222
+      nodePort: 30011
+  selector:
+    app: infinispan
+{{ end }}

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-service.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-service.yaml
@@ -1,0 +1,20 @@
+{{ if eq .Values.database "infinispan" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: infinispan
+  name: infinispan
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - port: 11222
+      name: console
+      protocol: TCP
+      targetPort: 11222
+  selector:
+    app: infinispan
+  sessionAffinity: None
+  type: ClusterIP
+{{ end }}

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -8,13 +8,25 @@ metadata:
 spec:
   hostname: keycloak.{{ .Values.hostname }}
   serverConfiguration:
+{{ if eq .Values.database "postgres" }}
     - name: db
       value: postgres
     - name: db-url
-{{ if eq .Values.database "postgres" }}
       value: jdbc:postgresql://postgres:5432/keycloak
-{{ else }}
+{{ else if eq .Values.database "cockroach" }}
+    - name: db
+      value: postgres
+    - name: db-url
       value: jdbc:postgresql://cockroach:26257/keycloak?sslmode=disable
+{{ else if eq .Values.database "infinispan" }}
+    - name: storage-hotrod-host
+      value: infinispan
+    - name: storage-hotrod-port
+      value: '11222'
+    - name: storage-hotrod-username
+      value: admin
+    - name: storage-hotrod-password
+      value: admin
 {{ end }}
     - name: db-pool-min-size
       value: {{ quote .Values.dbPoolInitialSize }}


### PR DESCRIPTION
Closes #168

@ahus1 @kami619 I was able to fix the problem with health checks. It was caused by the fact that we added:
```
- name: db
  value: postgres
```

even when Infinispan is used. I changed the condition to not include it and it works now.