### PR TITLE
Adding new capabilities to initialize-benchmark-entities.sh (fixes #159)

### DIFF
--- a/benchmark/initialize-benchmark-entities.sh
+++ b/benchmark/initialize-benchmark-entities.sh
@@ -7,11 +7,12 @@ set -o pipefail
 function usage {
   echo "Setup of test clients for the benchmark test with a pre-defined secret"
   echo "Usage: $(basename $0) -k KEYCLOAK_HOME -r REALM_NAME -c CLIENT_ID [-d]" 2>&1
-  echo '-k keycloak home path ex: /home/opt/keycloak-18.0.0 : default value KEYCLOAK_HOME env variable'
-  echo '-d delete the client and realm before re-creating them: default value is false'
-  echo '-r realm : default value realm-0'
-  echo '-c service account enabled client name : default value gatling'
-  echo '-d delete the client and realm : default value is false'
+  echo "-k keycloak home path ex: /home/opt/keycloak-18.0.0 : default value KEYCLOAK_HOME env variable"
+  echo "-d delete the client and realm before re-creating them: default value is false"
+  echo "-r realm : default value test-realm"
+  echo "-c service account enabled client name : default value gatling"
+  echo "-d delete the client and realm : default value is false"
+  echo "-u user : default username user-0. The user's password will always be the username plus the suffix -password, ex: for user-0 this would be user-0-password"
   exit 1
 }
 
@@ -29,14 +30,26 @@ function create_realm {
   fi
 }
 
-function create_client_assign_roles {
+function create_service_enabled_client_assign_roles {
   #Create the client application with Service Account Roles setup
   CID=$(kcadm.sh create clients -r $REALM_NAME -s clientId=$CLIENT_ID -s enabled=true -i)
   echo "INFO: Created New ${CLIENT_ID} Client with Client ID ${CID}"
   #Update the client with necessary attributes
-  kcadm.sh update clients/$CID -r $REALM_NAME  -s "secret=setup-for-benchmark" -s serviceAccountsEnabled=true  -s publicClient=false -s 'redirectUris=["http://localhost:8081"]'
+  kcadm.sh update clients/$CID -r $REALM_NAME  -s "secret=setup-for-benchmark" -s serviceAccountsEnabled=true  -s publicClient=false -s 'redirectUris=["*"]'
   #Assign the necessary Service Account based roles to the client
   kcadm.sh add-roles -r $REALM_NAME --uusername service-account-$CLIENT_ID --cclientid realm-management --rolename manage-clients --rolename view-users --rolename manage-realm --rolename manage-users
+}
+
+function create_oidc_client {
+  #Create the client application with OIDC for Auth Code scenarios with confidential client secret 
+  CID=$(kcadm.sh create clients -r $REALM_NAME -s clientId=client-0 -s clientAuthenticatorType=client-secret -s secret=client-0-secret -s publicClient=false -s 'redirectUris=["*"]' -s serviceAccountsEnabled=true -s enabled=true -i)
+  echo "INFO: Created New client-0 Client"
+}
+
+function create_user {
+ kcadm.sh create users -s username=$USER_NAME -s enabled=true -r $REALM_NAME
+ kcadm.sh set-password -r $REALM_NAME --username $USER_NAME --new-password $USER_NAME-password
+ echo "INFO: Created New user ${USER_NAME} in ${REALM_NAME}" 
 }
 
 function delete_entities {
@@ -49,11 +62,12 @@ function delete_entities {
 #main()
 #setting default values
 OPTIND=1
-REALM_NAME=realm-0
+REALM_NAME=test-realm
 CLIENT_ID=gatling
 DELETE_ENTITIES='false'
+USER_NAME=user-0
 
-while getopts "k:r:c:d" arg; do
+while getopts "k:r:u:c:d" arg; do
   case $arg in
     k) KEYCLOAK_HOME="$OPTARG";
         ;;
@@ -62,6 +76,8 @@ while getopts "k:r:c:d" arg; do
     c) CLIENT_ID="$OPTARG";
         ;;
     d) DELETE_ENTITIES=true;
+        ;;
+    u) USER_NAME="$OPTARG";
         ;;
     \?) echo "ERROR: Invalid option: -${OPTARG}" >&2
         usage
@@ -89,4 +105,6 @@ else
 fi
 
 create_realm
-create_client_assign_roles
+create_service_enabled_client_assign_roles
+create_oidc_client
+create_user

--- a/dataset/dataset-import.sh
+++ b/dataset/dataset-import.sh
@@ -7,7 +7,7 @@ set -e
 create_realms () {
   if [[ $1 =~ "--" ]]
   then
-    REALM_COUNT=10
+    REALM_COUNT=1
   else
     REALM_COUNT=$1
   fi

--- a/doc/benchmark/modules/ROOT/pages/preparing-keycloak.adoc
+++ b/doc/benchmark/modules/ROOT/pages/preparing-keycloak.adoc
@@ -59,13 +59,7 @@ Some scenarios require a service account with the clientId `gatling`:
 
 === Scripted configuration
 
-Instead of following the above manual steps, you can use this link:{github-files}/benchmark/manage_gatling_client.sh[manage_gatling_client.sh] script to do the setup for you.
-
-[WARNING]
-====
-The scripted setup currently does not set up users.
-Set up users manually, or use the xref:dataset-guide:ROOT:index.adoc[dataset provider].
-====
+Instead of following the above manual steps, you can use this link:{github-files}/benchmark/initialize-benchmark-entities.sh[initialize-benchmark-entities.sh] script to do the setup for you.
 
 Login to the Keycloak server using the kcadm cli script, which comes with any Keycloak distribution
 
@@ -75,19 +69,19 @@ $KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8081/au
 
 ----
 
-and then run this, for creating the needed realm and client
+and then run this, for creating the needed realm, client and user
 
 [source,shell]
 ----
-./manage_gatling_client.sh -c gatling
+./initialize-benchmark-entities.sh -r test-realm -c gatling -u user-0
 
 ----
 
-or run this, to recreate the realm and client for any reason
+or use a `-d` flag, to recreate the entities from scratch for any reason
 
 [source,shell]
 ----
-./manage_gatling_client.sh -d
+./initialize-benchmark-entities.sh -r test-realm -c gatling -u user-0 -d
 
 ----
 

--- a/doc/benchmark/modules/ROOT/pages/run/running-benchmark-cli.adoc
+++ b/doc/benchmark/modules/ROOT/pages/run/running-benchmark-cli.adoc
@@ -30,11 +30,11 @@ To start running tests, execute:
 
 By default, tests expect Keycloak to run on \http://localhost:8080/auth, and the default scenario is `keycloak.scenarion.authentication.ClientSecret`.
 
-To use a different server URL and scenario:
+To use a different server URL, realm and scenario:
 
 [source,bash]
 ----
-./kcb.sh --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=http://localhost:8080
+./kcb.sh --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=http://localhost:8080 --realm-name=test-realm
 ----
 
 See xref:scenario-overview.adoc[] for an overview over all available scenarios and their configuration options.

--- a/doc/benchmark/modules/ROOT/pages/scenario/authorization-code.adoc
+++ b/doc/benchmark/modules/ROOT/pages/scenario/authorization-code.adoc
@@ -38,10 +38,10 @@ bin/kcb.sh \
   --server-url=http://localhost:8080/ \
   --realm-name=realm-0 \
   --username=user-0 \
-  --user-password=user-password-0 \
-  --client-id=gatling \
-  --client-secret=setup-for-benchmark \
-  --client-redirect-uri=http://localhost:8081 \
+  --user-password=user-0-password \
+  --client-id=client-0 \
+  --client-secret=client-0-secret \
+  --client-redirect-uri=http://localhost:8080 \
   --log-http-on-failure
 ----
 

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -264,9 +264,9 @@ tasks:
     cmds:
       - bash -c ./isup.sh
       - bash -c "../keycloak-cli/keycloak/bin/kcadm.sh config credentials --server https://keycloak.{{.IP}}.nip.io/ --realm master --user admin --password admin"
-      - bash -c "../../benchmark/manage_gatling_client.sh -r realm-0 -d"
+      - bash -c "../../benchmark/initialize-benchmark-entities.sh -r test-realm -d"
     sources:
-      - ../../benchmark/manage_gatling_client.sh
+      - ../../benchmark/initialize-benchmark-entities.sh
       - .task/subtask-{{.TASK}}.yaml
       # if keycloak's database deployment changes, this restarts the DB and the Gatling user needs to be re-created
       - .task/status-keycloak-db.json


### PR DESCRIPTION
- Renaming the manage-gatling-client.sh to initialize-benchmark-entities.sh
- Adding new user creation capabilities to the script to create a default user to be able to kick off a single user Authentication scenarios (LoginUserPassword, ClientSecret, AuthorizationCode)
- The `initialize-benchmark-entities.sh` new oidc type client called `client-0` to support Authentication style scenarios and non-intersecting with the Service Enabled Client
- Updating the docs to reflect the latest state