### PR TITLE
Allows you to provision the environment in version 1.27 of minikube

### DIFF
--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -13,7 +13,7 @@ if [ "$GITHUB_ACTIONS" == "" ]; then
   fi
   minikube config set driver ${DRIVER}
   minikube config set container-runtime docker
-  minikube start --container-runtime=docker --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400"
+  minikube start --container-runtime=docker --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400" --kubernetes-version=v1.24.0
 fi
 minikube addons enable ingress
 rm -rf .task


### PR DESCRIPTION
Freezes the kubernetes version to 1.24 until activity #211 is complete.