### PR TITLE
Using an array when generating the CLI options for the downstream script

### DIFF
--- a/benchmark/src/main/content/bin/kcb.sh
+++ b/benchmark/src/main/content/bin/kcb.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
-case "`uname`" in
+case "$(uname)" in
     CYGWIN*)
-        CFILE = `cygpath "$0"`
-        RESOLVED_NAME=`readlink -f "$CFILE"`
+        CFILE=$(cygpath "$0")
+        RESOLVED_NAME=$(readlink -f "$CFILE")
         ;;
     Darwin*)
-        RESOLVED_NAME=`readlink "$0"`
+        RESOLVED_NAME=$(readlink "$0")
         ;;
     FreeBSD)
-        RESOLVED_NAME=`readlink -f "$0"`
+        RESOLVED_NAME=$(readlink -f "$0")
         ;;
     Linux)
-        RESOLVED_NAME=`readlink -f "$0"`
+        RESOLVED_NAME=$(readlink -f "$0")
         ;;
 esac
 
@@ -21,7 +21,7 @@ if [ "x$RESOLVED_NAME" = "x" ]; then
 fi
 
 GREP="grep"
-DIRNAME=`dirname "$RESOLVED_NAME"`
+DIRNAME=$(dirname "$RESOLVED_NAME")
 
 JAVA_OPTS="-server"
 JAVA_OPTS="${JAVA_OPTS} -Xmx1G -XX:+HeapDumpOnOutOfMemoryError"
@@ -29,7 +29,8 @@ JAVA_OPTS="${JAVA_OPTS} -Xmx1G -XX:+HeapDumpOnOutOfMemoryError"
 DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"
 
-CONFIG_ARGS=${CONFIG_ARGS:-""}
+CONFIG_ARGS=()
+SERVER_OPTS=()
 
 SCENARIO="keycloak.scenario.authentication.ClientSecret"
 
@@ -38,7 +39,7 @@ do
     case "$1" in
       --debug)
           DEBUG_MODE=true
-          if [ -n "$2" ] && [ "$2" = `echo "$2" | sed 's/-//'` ]; then
+          if [ -n "$2" ] && [ "$2" = "${2//-}" ]; then
               DEBUG_PORT=$2
               shift
           fi
@@ -55,10 +56,10 @@ do
           break
           ;;
       *)
-          if [[ $1 = --* || ! $1 =~ ^-.* ]]; then
-            CONFIG_ARGS="$CONFIG_ARGS -D${1:2}"
+          if [[ $1 = --* || ! $1 =~ ^-D.* ]]; then
+            CONFIG_ARGS+=("-D${1:2}")
           else
-            SERVER_OPTS="$SERVER_OPTS $1"
+            SERVER_OPTS+=("$1")
           fi
           ;;
     esac
@@ -67,7 +68,7 @@ done
 
 # Set debug settings if not already set
 if [ "$DEBUG_MODE" = "true" ]; then
-    DEBUG_OPT=`echo $JAVA_OPTS | $GREP "\-agentlib:jdwp"`
+    DEBUG_OPT=$(echo "$JAVA_OPTS" | $GREP "\-agentlib:jdwp")
     if [ "x$DEBUG_OPT" = "x" ]; then
         JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=y"
     else
@@ -77,4 +78,4 @@ fi
 
 CLASSPATH_OPTS="$DIRNAME/../lib/*"
 
-exec java $JAVA_OPTS $CONFIG_ARGS -cp $CLASSPATH_OPTS io.gatling.app.Gatling -bf $DIRNAME -rf "$DIRNAME/../results" -s $SCENARIO
+exec java $JAVA_OPTS "${SERVER_OPTS[@]}" "${CONFIG_ARGS[@]}" -cp $CLASSPATH_OPTS io.gatling.app.Gatling -bf $DIRNAME -rf "$DIRNAME/../results" -s $SCENARIO


### PR DESCRIPTION
This avoids blanks in parameters to split them.

Closes #204