### PR TITLE
Add new DB IOPS widgets to the keycloak-perf-tests grafana dashboard (Closes #197)

### DIFF
--- a/provision/minikube/monitoring/dashboards/keycloak-perf-tests.json
+++ b/provision/minikube/monitoring/dashboards/keycloak-perf-tests.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1657125398500,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -39,7 +38,7 @@
       },
       "id": 6,
       "panels": [],
-      "title": "Basic : CPU / Memory / Network",
+      "title": "Basic : CPU / Memory / Network / FS ",
       "type": "row"
     },
     {
@@ -112,7 +111,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom",
@@ -192,7 +192,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "9.0.5",
       "targets": [
         {
           "datasource": {
@@ -280,7 +280,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom",
@@ -360,7 +361,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "9.0.5",
       "targets": [
         {
           "datasource": {
@@ -448,7 +449,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom",
@@ -633,7 +635,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.1",
+      "pluginVersion": "9.0.5",
       "targets": [
         {
           "datasource": {
@@ -652,12 +654,312 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Node FS Reads + Writes Total",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 37,
+      "interval": "30",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(node_disk_writes_completed_total[2m]) + rate(node_disk_reads_completed_total[2m])",
+          "hide": false,
+          "legendFormat": "{{device}}@{{instance}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Node FS Total IOPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Node FS Total Read OPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 24
+      },
+      "id": 38,
+      "interval": "30",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(node_disk_reads_completed_total[2m])",
+          "hide": false,
+          "legendFormat": "{{device}}@{{instance}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Node FS Total Read OPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Node FS Total Write OPS",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 24
+      },
+      "id": 39,
+      "interval": "30",
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(node_disk_writes_completed_total[2m])",
+          "hide": false,
+          "legendFormat": "{{device}}@{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node FS Total Write OPS",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 34
       },
       "id": 10,
       "panels": [],
@@ -723,7 +1025,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 35
       },
       "id": 26,
       "options": {
@@ -731,7 +1033,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -816,7 +1119,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 25
+        "y": 35
       },
       "id": 27,
       "options": {
@@ -824,7 +1127,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -909,7 +1213,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 25
+        "y": 35
       },
       "id": 28,
       "options": {
@@ -917,7 +1221,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1003,7 +1308,7 @@
         "h": 11,
         "w": 6,
         "x": 0,
-        "y": 33
+        "y": 43
       },
       "id": 29,
       "options": {
@@ -1011,7 +1316,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1097,7 +1403,7 @@
         "h": 11,
         "w": 6,
         "x": 6,
-        "y": 33
+        "y": 43
       },
       "id": 30,
       "options": {
@@ -1105,7 +1411,8 @@
           "calcs": [
             "min",
             "max",
-            "lastNotNull"
+            "lastNotNull",
+            "mean"
           ],
           "displayMode": "table",
           "placement": "bottom"
@@ -1191,7 +1498,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 43
       },
       "id": 31,
       "options": {
@@ -1241,7 +1548,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 54
       },
       "id": 8,
       "panels": [],
@@ -1308,7 +1615,7 @@
         "h": 10,
         "w": 6,
         "x": 0,
-        "y": 45
+        "y": 55
       },
       "id": 12,
       "options": {
@@ -1405,7 +1712,7 @@
         "h": 10,
         "w": 6,
         "x": 6,
-        "y": 45
+        "y": 55
       },
       "id": 13,
       "options": {
@@ -1502,7 +1809,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 45
+        "y": 55
       },
       "id": 16,
       "options": {
@@ -1608,7 +1915,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 65
       },
       "id": 15,
       "options": {
@@ -1726,7 +2033,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 65
       },
       "id": 32,
       "options": {
@@ -1778,7 +2085,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 73
       },
       "id": 20,
       "panels": [],
@@ -1786,52 +2093,43 @@
       "type": "row"
     },
     {
-      "id": 22,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 64
-      },
-      "type": "timeseries",
-      "title": "DB Connection Usage",
       "datasource": {
-        "uid": "PBFA97CFB590B2093",
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "linear",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
             "barAlignment": 0,
-            "lineWidth": 1,
+            "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
-            "spanNulls": false,
-            "showPoints": "auto",
-            "pointSize": 5,
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "axisPlacement": "auto",
-            "axisLabel": "",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
-            },
-            "axisSoftMin": 0
-          },
-          "color": {
-            "mode": "palette-classic"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -1859,27 +2157,34 @@
               {
                 "id": "custom.stacking",
                 "value": {
-                  "mode": "none",
-                  "group": "A"
+                  "group": "A",
+                  "mode": "none"
                 }
               }
             ]
           }
         ]
       },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "id": 22,
       "options": {
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        },
         "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
           "calcs": [
             "min",
             "max",
             "lastNotNull"
-          ]
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -1902,25 +2207,27 @@
           },
           "editorMode": "code",
           "expr": "pg_stat_activity_count{datname=\"keycloak\"} > 0",
+          "format": "time_series",
           "hide": false,
           "legendFormat": "{{state}}",
           "range": true,
-          "refId": "B",
-          "format": "time_series"
+          "refId": "B"
         },
         {
           "datasource": {
-            "uid": "PBFA97CFB590B2093",
-            "type": "prometheus"
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
           },
-          "refId": "C",
-          "hide": false,
           "editorMode": "code",
           "expr": "sum(pg_stat_activity_count{datname!=\"keycloak\"}) > 0",
+          "hide": false,
           "legendFormat": "other db connections",
-          "range": true
+          "range": true,
+          "refId": "C"
         }
-      ]
+      ],
+      "title": "DB Connection Usage",
+      "type": "timeseries"
     },
     {
       "datasource": {
@@ -1982,7 +2289,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 74
       },
       "id": 23,
       "options": {
@@ -2076,7 +2383,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 72
+        "y": 82
       },
       "id": 24,
       "options": {
@@ -2170,7 +2477,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 72
+        "y": 82
       },
       "id": 21,
       "options": {
@@ -2264,7 +2571,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 80
+        "y": 90
       },
       "id": 18,
       "options": {


### PR DESCRIPTION


created a widget to track the 5m rate of the  write, read and total IOPS with min,max,current,mean values plotted by each container

Sample screen grab of the widgets

![image](https://user-images.githubusercontent.com/3415105/194604879-41c0af94-1f69-430f-b9f7-2fd02e518178.png)

------------------------------------------------------

Closes #197