### PR TITLE
handle additional forward slashes in the server url config value (fixes #229)

### DIFF
--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -83,7 +83,7 @@ class KeycloakScenarioBuilder {
       userPassword = Config.userPassword
     }
 
-    var redirectUri = serverUrl.concat("/realms/").concat(realmName).concat("/account");
+    var redirectUri = serverUrl.stripSuffix("/").concat("/realms/").concat(realmName).concat("/account");
 
     if (Config.clientRedirectUrl != null) {
       redirectUri = Config.clientRedirectUrl;


### PR DESCRIPTION
handle additional forward slashes in the server url config value by stripping the suffix of the stored serverUrl scala variable

-----

Closes #229 