### PR TITLE
Correcting installation guide for yq

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-yq.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-yq.adoc
@@ -9,7 +9,7 @@ It needs to be installed before the  xref:installation.adoc[] can begin.
 
 The recommended installation is to download the latest binary from the task GitHub releases and put it into the user's `~/bin` directory.
 
-The installation guide is available in the https://taskfile.dev/installation/#get-the-binary[Task installation guide].
+The installation guide is available in the https://github.com/mikefarah/yq/#install[yq installation guide].
 
 == Optional installation steps for yq
 


### PR DESCRIPTION
#210 The yq installation guide is incorrectly linked to task installation guide