### PR TITLE
extend the fix around redirect_uri to dataset module

### DIFF
--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.DELETE;
@@ -66,6 +67,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.cache.CacheRealmProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -946,6 +948,11 @@ public class DatasetResourceProvider implements RealmResourceProvider {
             // Enable service account
             if(Boolean.parseBoolean(config.getIsServiceAccountClient())) {
                 new ClientManager(new RealmManager(session)).enableServiceAccount(model);
+            }
+
+            // Set "post.logout.redirect.uris"
+            if(OIDCAdvancedConfigWrapper.fromClientModel(model).getPostLogoutRedirectUris() == null) {
+                OIDCAdvancedConfigWrapper.fromClientModel(model).setPostLogoutRedirectUris(Collections.singletonList("+"));
             }
 
             context.incClientCount();


### PR DESCRIPTION
Context: Even though we fixed the redirect_uri used for logouts after a breaking change, we only did the change in the initialize_benchmark_entities.sh script and subsequent clients it would create. However, we would need this change also in the dataset module, so that, any clients which are created at scale would also work without issue.

As part of it, I have re-used the pattern from this PR [commit](https://github.com/keycloak/keycloak/commit/c00514d659f4b7416abecf35d1abb4f959675ee4#diff-e0e8f2c00bda6b7c51673acec8bac747f21b36c4dace3eaabcd6b3b7feee2043R122-R124) from Keycloak repository

- set the client with 'post.logout.redirect.uris' attribute and value '+' if logout redirect uris are set to null

@ahus1 I have generated a dataset module with this change and the logout api performed by the clients created by the dataset module doesn't fail anymore

Relates to #220