### PR TITLE
Updating the Preparing Keycloak guide

### DIFF
--- a/doc/benchmark/modules/ROOT/pages/preparing-keycloak.adoc
+++ b/doc/benchmark/modules/ROOT/pages/preparing-keycloak.adoc
@@ -61,20 +61,33 @@ Some scenarios require a service account with the clientId `gatling`:
 
 Instead of following the above manual steps, you can use this link:{github-files}/benchmark/src/main/content/bin/initialize-benchmark-entities.sh[initialize-benchmark-entities.sh] script to do the setup for you.
 
-Login to the Keycloak server using the kcadm cli script, which comes with any Keycloak distribution
+Specify the path to Keycloak distribution directory as KEYCLOAK_HOME.
+
+[NOTE]
+====
+If you have installed the keycloak using xref:kubernetes-guide::installation.adoc[minikube],
+. KEYCLOAK_HOME could be set using the folllowing command
+[source,shell]
+----
+export KEYCLOAK_HOME=provision/keycloak-cli/keycloak
+----
+. The keycloak server url is expected to look something like 'https://keycloak.192.168.12.345'.
+====
+
+Login to the Keycloak server using the kcadm cli script, which comes with any Keycloak distribution.
 
 [source,shell]
 ----
-$KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8081/auth --realm master --user admin --password admin
-
+$KEYCLOAK_HOME/bin/kcadm.sh config credentials --server https://keycloak.192.168.12.345.nip.io --realm master --user admin --password admin
 ----
 
 and then run this, for creating the needed realm, client and user
 
+WARNING: If you want to use the scripted configuration, extract the downloaded xref:downloading-benchmark.adoc[Keycloak Benchmark module]. initialize-benchmark-entities.sh is located in the bin folder of this module.
+
 [source,shell]
 ----
 ./initialize-benchmark-entities.sh -r test-realm -c gatling -u user-0
-
 ----
 
 or use a `-d` flag, to recreate the entities from scratch for any reason

--- a/doc/benchmark/modules/ROOT/pages/run/running-benchmark-cli.adoc
+++ b/doc/benchmark/modules/ROOT/pages/run/running-benchmark-cli.adoc
@@ -34,7 +34,7 @@ To use a different server URL, realm and scenario:
 
 [source,bash]
 ----
-./kcb.sh --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=http://localhost:8080 --realm-name=test-realm
+./kcb.sh --scenario=keycloak.scenario.authentication.AuthorizationCode --server-url=https://keycloak.192.168.12.345.nip.io --realm-name=test-realm
 ----
 
 See xref:scenario-overview.adoc[] for an overview over all available scenarios and their configuration options.


### PR DESCRIPTION
* Scripted configuration uses the auth in the server url http://localhost:8081/auth due to which it fails with 
`Logging into http://keycloak.minikubeIp.nip.io/auth as user admin of realm master
null [RESTEASY003210: Could not find resource for full path: http://keycloak.192.168.64.17.nip.io/auth/realms/master/protocol/openid-connect/token]`
* Making the server url more realistic as it uses  http://keycloak.minikubeIp.nip.io instead of localhost
* Specifying KEYCLOAK_HOME is never mentioned in the guide