### PR TITLE
Expose the SQLPAD_QUERY_RESULT_MAX_ROWS in sqlpad app

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/util/sqlpad.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/util/sqlpad.adoc
@@ -13,6 +13,8 @@ include::partial$minikube-ip-change.adoc[]
 
 The username is `admin` with the password `admin`.
 
+You can update the configurations associated with SQL Pad container https://github.com/keycloak/keycloak-benchmark/blob/main/provision/minikube/keycloak/templates/sqlpad.yaml#L25[here]
+
 [.shadow]
 image::util/sqlpad.png[]
 

--- a/provision/minikube/keycloak/templates/sqlpad.yaml
+++ b/provision/minikube/keycloak/templates/sqlpad.yaml
@@ -65,6 +65,8 @@ spec:
               value: 'true'
             - name: SQLPAD_CONNECTIONS__pgdemo__idleTimeoutSeconds
               value: '86400'
+            - name: SQLPAD_QUERY_RESULT_MAX_ROWS
+              value: '100000'
           image: sqlpad/sqlpad:6.11.0
           imagePullPolicy: Always
           startupProbe:


### PR DESCRIPTION
Expose the SQLPAD_QUERY_RESULT_MAX_ROWS configuration variable to be able to configure max rows displayed as a result of a query

Fixes #254