### PR TITLE
Use a valid SemVer format for the SNAPSHOT version

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/util/custom-image-for-keycloak.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/util/custom-image-for-keycloak.adoc
@@ -27,7 +27,7 @@ KC_CONTAINER_IMAGE=quay.io/keycloak/keycloak:20.0.1
 == Building a custom Keycloak image and using it
 
 . Check out https://github.com/keycloak/keycloak[Keycloak's Git repository].
-. Build using `mvn clean install -DskipTests` to create a `keycloak-999-SNAPSHOT.tar.gz` in folder `/quarkus/dist/target`.
+. Build using `mvn clean install -DskipTests` to create a `keycloak-999.0.0-SNAPSHOT.tar.gz` in folder `/quarkus/dist/target`.
 . Configure the Minikube environment to use the locally built image.
 +
 .Example entry in the `.env` file

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <description>Keycloak Benchmark Parent</description>
 
   <properties>
-    <keycloak.version>999-SNAPSHOT</keycloak.version>
+    <keycloak.version>999.0.0-SNAPSHOT</keycloak.version>
     <jboss-jaxrs-api_2.1_spec>2.0.1.Final</jboss-jaxrs-api_2.1_spec>
     <resteasy.version>3.15.1.Final</resteasy.version>
     <junit.version>4.13.2</junit.version>

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -258,7 +258,7 @@ tasks:
       # if the nightly release doesn't exist, download a specific release as a fallback
       # revisit once https://github.com/keycloak-rel/keycloak-rel/issues/47 as been fixed
       - >
-        curl -L -f https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999-SNAPSHOT.zip -o keycloak-cli/keycloak.zip ||
+        curl -L -f https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.zip -o keycloak-cli/keycloak.zip ||
         curl -L -f https://github.com/keycloak/keycloak/releases/download/19.0.1/keycloak-19.0.1.zip -o keycloak-cli/keycloak.zip
     status:
       - test -f keycloak-cli/keycloak.zip
@@ -272,11 +272,11 @@ tasks:
     dir: ..
     cmds:
       # remove temporary folders to be extra safe
-      - rm -rf keycloak-cli/keycloak-999-SNAPSHOT keycloak-cli/keycloak-19.0.1
+      - rm -rf keycloak-cli/keycloak-999.0.0-SNAPSHOT keycloak-cli/keycloak-19.0.1
       - rm -rf keycloak-cli/keycloak
       - unzip -o -q keycloak-cli/keycloak.zip -d keycloak-cli
       # the output folder depends on the version we're about to unpack
-      - mv keycloak-cli/keycloak-999-SNAPSHOT keycloak-cli/keycloak || mv keycloak-cli/keycloak-19.0.1 keycloak-cli/keycloak
+      - mv keycloak-cli/keycloak-999.0.0-SNAPSHOT keycloak-cli/keycloak || mv keycloak-cli/keycloak-19.0.1 keycloak-cli/keycloak
     sources:
       - keycloak-cli/keycloak.zip
       - minikube/.task/subtask-{{.TASK}}.yaml


### PR DESCRIPTION
Changes the default version string from `999-SNAPSHOT` to `999.0.0-SNAPSHOT`. This makes it a valid version under the [Semantic Versioning](https://semver.org/) standard.

The motivation for this change is to make versioning interoperable between Maven and NPM, as the latter only allows for Semantic Versioning. This allows for simplification in the release process, as we no longer need to convert version numbers from one to the other.

For more information see https://github.com/keycloak/keycloak/issues/17335.