### PR TITLE
Add support for Keycloak scaling and setting resource limits

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/customizing-deployment.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/customizing-deployment.adoc
@@ -131,6 +131,43 @@ When the image name starts with `localhost/`, the image will be expected to be b
 +
 See xref:util/custom-image-for-keycloak.adoc[] on how to build a local image.
 
+KC_INSTANCES::
+Sets the number of Keycloak instances.
++
+Default value: `1`
+
+KC_CPU_LIMITS::
+Sets CPU limits per Keycloak pod.
++
+Default value: `1`
++
+The value must adhere to the https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu[Kubernetes CPU units] format.
+
+KC_MEMORY_LIMITS_MB::
+Sets memory limits in MB per Keycloak pod.
++
+Default value: `1024`
+
+KC_HEAP_INIT_MB::
+Sets the initial heap space size in MB per Keycloak JVM.
++
+Default value: `64`.
+
+KC_HEAP_MAX_MB::
+Sets the maximum heap space size in MB per Keycloak JVM.
++
+Default value: `512`.
+
+KC_METASPACE_INIT_MB::
+Sets the initial meta space size in MB per Keycloak JVM.
++
+Default value: `96`.
+
+KC_METASPACE_MAX_MB::
+Sets the maximum meta space size in MB per Keycloak JVM.
++
+Default value: `256`.
+
 == Available Benchmark options
 
 The following configuration options are available to configure the helper applications.

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -15,6 +15,15 @@ vars:
   KC_DATABASE: '{{default "postgres" .KC_DATABASE}}'
   KC_OPERATOR_TAG: '{{default "nightly" .KC_OPERATOR_TAG}}'
   KC_CONTAINER_IMAGE: '{{default "" .KC_CONTAINER_IMAGE}}'
+  KC_INSTANCES: '{{default "1" .KC_INSTANCES}}'
+  KC_CPU_REQUESTS: '{{default "0" .KC_CPU_REQUESTS}}'
+  KC_CPU_LIMITS: '{{default "1" .KC_CPU_LIMITS}}'
+  KC_MEMORY_REQUESTS_MB: '{{default "1024" .KC_MEMORY_REQUESTS_MB}}'
+  KC_MEMORY_LIMITS_MB: '{{default "1024" .KC_MEMORY_LIMITS_MB}}'
+  KC_HEAP_INIT_MB: '{{default "64" .KC_HEAP_INIT_MB}}'
+  KC_HEAP_MAX_MB: '{{default "512" .KC_HEAP_MAX_MB}}'
+  KC_METASPACE_INIT_MB: '{{default "96" .KC_METASPACE_INIT_MB}}'
+  KC_METASPACE_MAX_MB: '{{default "256" .KC_METASPACE_MAX_MB}}'
 
 dotenv: ['.env']
 
@@ -86,6 +95,15 @@ tasks:
       - echo {{.KC_DATABASE}} > .task/var-KC_DATABASE
       - echo {{.KC_OPERATOR_TAG}} > .task/var-KC_OPERATOR_TAG
       - echo {{.KC_CONTAINER_IMAGE}} > .task/var-KC_CONTAINER_IMAGE
+      - echo {{.KC_INSTANCES}} > .task/var-KC_INSTANCES
+      - echo {{.KC_CPU_REQUESTS}} > .task/var-KC_CPU_REQUESTS
+      - echo {{.KC_CPU_LIMITS}} > .task/var-KC_CPU_LIMITS
+      - echo {{.KC_MEMORY_REQUESTS_MB}} > .task/var-KC_MEMORY_REQUESTS_MB
+      - echo {{.KC_MEMORY_LIMITS_MB}} > .task/var-KC_MEMORY_LIMITS_MB
+      - echo {{.KC_HEAP_INIT_MB}} > .task/var-KC_HEAP_INIT_MB
+      - echo {{.KC_HEAP_MAX_MB}} > .task/var-KC_HEAP_MAX_MB
+      - echo {{.KC_METASPACE_INIT_MB}} > .task/var-KC_METASPACE_INIT_MB
+      - echo {{.KC_METASPACE_MAX_MB}} > .task/var-KC_METASPACE_MAX_MB
     run: once
     sources:
       - .task/subtask-{{.TASK}}.yaml
@@ -98,6 +116,15 @@ tasks:
       - test "{{.KC_DATABASE}}" == "$(cat .task/var-KC_DATABASE)"
       - test "{{.KC_OPERATOR_TAG}}" == "$(cat .task/var-KC_OPERATOR_TAG)"
       - test "{{.KC_CONTAINER_IMAGE}}" == "$(cat .task/var-KC_CONTAINER_IMAGE)"
+      - test "{{.KC_INSTANCES}}" == "$(cat .task/var-KC_INSTANCES)"
+      - test "{{.KC_CPU_REQUESTS}}" == "$(cat .task/var-KC_CPU_REQUESTS)"
+      - test "{{.KC_CPU_LIMITS}}" == "$(cat .task/var-KC_CPU_LIMITS)"
+      - test "{{.KC_MEMORY_REQUESTS_MB}}" == "$(cat .task/var-KC_MEMORY_REQUESTS_MB)"
+      - test "{{.KC_MEMORY_LIMITS_MB}}" == "$(cat .task/var-KC_MEMORY_LIMITS_MB)"
+      - test "{{.KC_HEAP_INIT_MB}}" == "$(cat .task/var-KC_HEAP_INIT_MB)"
+      - test "{{.KC_HEAP_MAX_MB}}" == "$(cat .task/var-KC_HEAP_MAX_MB)"
+      - test "{{.KC_METASPACE_INIT_MB}}" == "$(cat .task/var-KC_METASPACE_INIT_MB)"
+      - test "{{.KC_METASPACE_MAX_MB}}" == "$(cat .task/var-KC_METASPACE_MAX_MB)"
 
   prometheus:
     deps:
@@ -337,6 +364,15 @@ tasks:
         --set storage={{.KC_STORAGE}}
         --set database={{.KC_DATABASE}}
         --set keycloakImage={{.KC_CONTAINER_IMAGE}}
+        --set instances={{ .KC_INSTANCES }}
+        --set cpuRequests={{ .KC_CPU_REQUESTS }}
+        --set cpuLimits={{ .KC_CPU_LIMITS }}
+        --set memoryRequestsMB={{ .KC_MEMORY_REQUESTS_MB }}
+        --set memoryLimitsMB={{ .KC_MEMORY_LIMITS_MB }}
+        --set heapInitMB={{ .KC_HEAP_INIT_MB }}
+        --set heapMaxMB={{ .KC_HEAP_MAX_MB }}
+        --set metaspaceInitMB={{ .KC_METASPACE_INIT_MB }}
+        --set metaspaceMaxMB={{ .KC_METASPACE_MAX_MB }}
         keycloak
       - >
         bash -c '

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -75,7 +75,7 @@ spec:
         key: password
   http:
     tlsSecret: keycloak-tls-secret
-  instances: 1
+  instances: {{ .Values.instances }}
   unsupported:
     podTemplate:
       metadata:
@@ -119,7 +119,9 @@ spec:
 {{ end }}
               - name: JAVA_OPTS_APPEND
                 # using non-blocking random, make DNS lookups expire after 10 seconds and not cache them forever
-                value: >-
+                value: >
+                  -Xms{{ .Values.heapInitMB }}m -Xmx{{ .Values.heapMaxMB }}m
+                  -XX:MetaspaceSize={{ .Values.metaspaceInitMB }}m -XX:MaxMetaspaceSize={{ .Values.metaspaceMaxMB }}m
                   -Djava.security.egd=file:/dev/urandom -Dnetworkaddress.cache.ttl=10 -XX:+ExitOnOutOfMemoryError
                   -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8787
 {{- if .Values.otel }}
@@ -145,10 +147,13 @@ spec:
               - containerPort: 8787
                 protocol: TCP
                 name: jvmdebug
-            resources: {}
-              # limits:
-              #  cpu: "2000m"
-              #  memory: "1500Mi"
+            resources: 
+              requests:
+                cpu: "{{ .Values.cpuRequests }}"
+                memory: "{{ .Values.memoryRequestsMB }}M"
+              limits:
+                cpu: "{{ .Values.cpuLimits }}"
+                memory: "{{ .Values.memoryLimitsMB }}M"
             startupProbe:
               httpGet:
                 path: /health/ready

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -13,3 +13,12 @@ storage:
 database: postgres
 disableCaches: false
 keycloakImage: ''
+instances: 1
+cpuRequests: 0
+cpuLimits: 1
+memoryRequestsMB: 1024
+memoryLimitsMB: 1024
+heapInitMB: 64
+heapMaxMB: 512
+metaspaceInitMB: 96
+metaspaceMaxMB: 256


### PR DESCRIPTION
Added support for the following options:
`KC_INSTANCES` - number of KC instances
`KC_CPU_REQUESTS` - minimum cores per KC pod, defaults to `0`
`KC_CPU_LIMITS` - maximum cores per KC pod, defaults to `1`
`KC_MEMORY_REQUESTS_MB` - minimum memory per KC pod in MB, defaults to `1024`
`KC_MEMORY_LIMITS_MB` - maximum memory per KC pod in MB, defaults to `1024`
`KC_HEAP_INIT_MB` - initial heap space size
`KC_HEAP_MAX_MB` - max heap space size
`KC_METASPACE_INIT_MB` - initial meta space size
`KC_METASPACE_MAX_MB` - max meta space size