### PR TITLE
Add "mixed" (JPA/HotRod) storage setup

### DIFF
--- a/.github/workflows/provision-minikube.yml
+++ b/.github/workflows/provision-minikube.yml
@@ -108,6 +108,19 @@ jobs:
           task KC_DATABASE=infinispan KC_STORAGE=hotrod dataset-import -- -a clear-status-completed
           task KC_DATABASE=infinispan KC_STORAGE=hotrod dataset-import -- -a create-realms -r 1 -c 5 -u 5 -i 1000
           task KC_DATABASE=infinispan KC_STORAGE=hotrod dataset-import -- -a status-completed
+      - name: Provision JPA Map store on Hotrod (In-Memory store)
+        working-directory: provision/minikube
+        run: |
+          PATH=$PATH:$GITHUB_WORKSPACE/bin
+          task KC_DATABASE=postgres+infinispan KC_STORAGE=jpa+hotrod
+          kubectl get pods -A
+          kubectl get events -A
+      - name: Create Dataset on Infinispan Hotrod Store
+        working-directory: provision/minikube
+        run: |
+          task KC_DATABASE=postgres+infinispan KC_STORAGE=jpa+hotrod dataset-import -- -a clear-status-completed
+          task KC_DATABASE=postgres+infinispan KC_STORAGE=jpa+hotrod dataset-import -- -a create-realms -r 1 -c 5 -u 5 -i 1000
+          task KC_DATABASE=postgres+infinispan KC_STORAGE=jpa+hotrod dataset-import -- -a status-completed
       - name: Provision JPA Map store on CHM (File store)
         working-directory: provision/minikube
         run: |

--- a/doc/kubernetes/modules/ROOT/nav.adoc
+++ b/doc/kubernetes/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 ** xref:storage/cockroach-single.adoc[]
 ** xref:storage/cockroach-operator.adoc[]
 ** xref:storage/infinispan.adoc[]
+** xref:storage/postgres-infinispan.adoc[]
 ** xref:storage/concurrent-hash-map.adoc[]
 * xref:error-messages.adoc[]
 * xref:load-behavior.adoc[]

--- a/doc/kubernetes/modules/ROOT/pages/customizing-deployment.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/customizing-deployment.adoc
@@ -60,6 +60,10 @@ See xref:storage/cockroach-operator.adoc[] for more information.
 +
 See xref:storage/infinispan.adoc[] for more information.
 
+* `postgres+infinispan` -- deploy mixed setup with session data stored in Infinispan and all other entities stored in PostgreSQL.
++
+See xref:storage/postgres-infinispan.adoc[] for more information.
+
 * `none` -- deploy no data store.
 +
 See xref:storage/concurrent-hash-map.adoc[] for more information.
@@ -85,6 +89,11 @@ See xref:storage/postgres.adoc[], xref:storage/cockroach-single.adoc[] or xref:s
 This requires `KC_DATABASE` to be set to `infinispan`.
 +
 See xref:storage/infinispan.adoc[] for more information.
+
+* `jpa+hotrod` -- deploys Keycloak with the new map store configured for HotRod for sessions and JPA for all other entities.
+This requires `KC_DATABASE` to be set to `postgres+infinispan`.
++
+See xref:storage/postgres-infinispan.adoc[] for more information.
 
 * `chm` -- deploys Keycloak with the new map store configured with Concurrent Hash Map, which is an in-memory store that is not shared between Keycloak instances.
 +

--- a/doc/kubernetes/modules/ROOT/pages/error-messages.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/error-messages.adoc
@@ -47,7 +47,11 @@ This error message can appear when running Keycloak with CockroachDB, both xref:
 This might happen during the load test while Keycloak processes requests.
 
 Cause::
-Some transactions are not fully serializable, therefore, the database rolls back the transaction and asks the caller to repeat the request.
+Some transactions are not fully serializable as data has been modified in parallel transactions.
+
+Effect::
+The database rolls back the transaction and asks the caller to repeat the request.
+Some users see error messages.
 
 Remedy::
 * Analyze the request/URL where this happens by looking at the log, and discuss this with engineers.
@@ -59,3 +63,41 @@ SELECT DISTINCT ti.descriptor_name as table_name, us.table_id
   FROM  crdb_internal.index_usage_statistics us, crdb_internal.table_indexes ti
   WHERE us.table_id = ti.descriptor_id ORDER BY us.table_id ASC;
 ----
+
+== Keycloak message `prepared transactions are disabled`
+
+Full message::
+org.postgresql.util.PSQLException: ERROR: prepared transactions are disabled.
+Hint: Set max_prepared_transactions to a nonzero value.
+
+Context::
+This happens when the transaction manager or Quarkus handles more than one transaction in a request, and one of the transactions is handled by a PostgreSQL database.
+
+Cause::
+Once the transaction manager of Quarkus bundles two transactions, it sends a `PREPARE TRANSACTION` command to the database before sending the commit after all transactions have been prepared.
+For this to work, the database needs to have the `max_prepared_transactions` parameter set.
+
+Effect::
+No transactions against the PostgreSQL database complete.
+
+Remedy::
+Pass the parameters `-c max_prepared_transactions=xxx` to the database.
+For the containerized database in the Kubernetes setup, this has been configured in `link:{github-files}/provision/minikube/keycloak/templates/postgres/postgres-deployment.yaml[postgres-deployment.yaml]`.
+
+== Keycloak message `ARJUNA012225: cannot access root of object store`
+
+Full message::
+ARJUNA012225: FileSystemStore::setupStore - cannot access root of object store: ObjectStore/ShadowNoFileLockStore/defaultStore/
+
+Context::
+This happens when the transaction manager or Quarkus handles more than one transaction in a request and attempts to locally persist the state of the transaction.
+
+Cause::
+The working directory of Keycloak is not writable in the Keycloak container, therefore writing the state fails.
+
+Effect::
+No transactions against any store participating in the JTA transaction complete, therefore Keycloak will not start.
+
+Remedy::
+Via the environment variable `QUARKUS_TRANSACTION_MANAGER_OBJECT_STORE_DIRECTORY` pass in a folder that is writable.
+For the containerized Keycloak setup in the Kubernetes setup, this has been configured in `link:{github-files}provision/minikube/keycloak/templates/keycloak.yaml[keycloak.yaml]`.

--- a/doc/kubernetes/modules/ROOT/pages/storage-configurations.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/storage-configurations.adoc
@@ -33,6 +33,10 @@ The following table lists the different storages:
 |
 |✅
 
+|xref:storage/postgres-infinispan.adoc[PostgreSQL + Infinispan]
+|
+|✅
+
 |xref:storage/concurrent-hash-map.adoc[Concurrent Hash Map]
 |
 |✅

--- a/doc/kubernetes/modules/ROOT/pages/storage/infinispan.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/storage/infinispan.adoc
@@ -1,5 +1,5 @@
 = Using Infinispan storage
-:description: The deployment of Keycloak can use an external infinispan instance when deployed with the new map storage.
+:description: The deployment of Keycloak can use an external Infinispan instance when deployed with the new map storage.
 
 {description}
 

--- a/doc/kubernetes/modules/ROOT/pages/storage/postgres-infinispan.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/storage/postgres-infinispan.adoc
@@ -1,0 +1,34 @@
+= Using mixed PostgreSQL and Infinispan storage
+:description: The deployment of Keycloak can use a PostgreSQL database and an external infinispan Instance when deployed with the new map storage.
+
+{description}
+
+This mixed setup mirrors what the Legacy store: auth sessions, user sessions, login failures, and single use objects are stored via the Hot Rod protocol in an Infinispan instance, all other entities are stored via JPA in a PostgreSQL instance.
+All stores use the new map store implementation.
+
+== Enabling Infinispan
+
+Using an external Infinispan instance is available in Keycloak's new HotRod map storage.
+It can be enabled via the following settings in the `.env` file in the `provision/kubernetes` folder:
+
+[source]
+----
+KC_DATABASE=postgres+infinispan
+KC_STORAGE=jpa+hotrod
+----
+
+See xref:customizing-deployment.adoc[] for a list of all configuration options.
+
+include::partial$rerun-task-after-changes.adoc[]
+
+The deployment adds a new Infinispan pod to the minikube setup and removes all other storage pods that are no longer necessary.
+Every time the pod is restarted, the database is cleared.
+
+== Further reading
+
+To verify the setup and to access the consoles for PostgreSQL and Infinispan, visit the respective pages:
+
+* xref:./postgres.adoc[]
+* xref:./infinispan.adoc[]
+
+

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -61,7 +61,7 @@ tasks:
     cmds:
       - >
         bash -c '
-        if [ "{{.KC_DATABASE}}" == "mixed" ];
+        if [ "{{.KC_DATABASE}}" == "postgres+infinispan" ];
         then kubectl delete deployment/postgres -n keycloak || exit 0;
              kubectl delete deployment/infinispan -n keycloak || exit 0;
         else
@@ -392,7 +392,7 @@ tasks:
         then kubectl -n keycloak -o yaml get crdbclusters.crdb.cockroachlabs.com/cockroach > .task/status-{{.TASK}}-db.json;
         elif [ "{{.KC_DATABASE}}" == "cockroach-single" ];
         then kubectl get deployment/cockroach -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json;
-        elif [ "{{.KC_DATABASE}}" == "mixed" ];
+        elif [ "{{.KC_DATABASE}}" == "postgres+infinispan" ];
         then kubectl get deployment/postgres -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json;
              kubectl get deployment/infinispan -n keycloak -o=jsonpath="{.spec}" >> .task/status-{{.TASK}}-db.json;
         elif [ "{{.KC_DATABASE}}" != "none" ];

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -59,7 +59,14 @@ tasks:
     deps:
       - split
     cmds:
-      - bash -c "kubectl delete deployment/{{.KC_DATABASE}} -n keycloak || exit 0"
+      - >
+        bash -c '
+        if [ "{{.KC_DATABASE}}" == "mixed" ];
+        then kubectl delete deployment/postgres -n keycloak || exit 0;
+             kubectl delete deployment/infinispan -n keycloak || exit 0;
+        else
+        kubectl delete deployment/{{.KC_DATABASE}} -n keycloak || exit 0;
+        fi'
       - >
         bash -c '
         if [ "{{.KC_DATABASE}}" == "cockroach-single" ];
@@ -385,6 +392,9 @@ tasks:
         then kubectl -n keycloak -o yaml get crdbclusters.crdb.cockroachlabs.com/cockroach > .task/status-{{.TASK}}-db.json;
         elif [ "{{.KC_DATABASE}}" == "cockroach-single" ];
         then kubectl get deployment/cockroach -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json;
+        elif [ "{{.KC_DATABASE}}" == "mixed" ];
+        then kubectl get deployment/postgres -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json;
+             kubectl get deployment/infinispan -n keycloak -o=jsonpath="{.spec}" >> .task/status-{{.TASK}}-db.json;
         elif [ "{{.KC_DATABASE}}" != "none" ];
         then kubectl get deployment/{{.KC_DATABASE}} -n keycloak -o=jsonpath="{.spec}" > .task/status-{{.TASK}}-db.json;
         else echo "none" > .task/status-{{.TASK}}-db.json;

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-deployment.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan") }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-deployment.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "infinispan" }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-ingress.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-ingress.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "infinispan" }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-ingress.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-ingress.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan") }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "infinispan" }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-service.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-service.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan") }}
 ---
 apiVersion: v1
 kind: Service

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-service.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-service.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "infinispan" }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "mixed") }}
 ---
 apiVersion: v1
 kind: Service

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -9,7 +9,7 @@ spec:
   hostname:
     hostname: keycloak.{{ .Values.hostname }}
   additionalOptions:
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
     - name: db
       value: postgres
     - name: db-url
@@ -24,21 +24,8 @@ spec:
       value: postgres
     - name: db-url
       value:  jdbc:postgresql://cockroach-public:26257/keycloak?sslcert=%2Fcockroach%2Fcockroach-certs%2Fclient.root.crt&sslkey=%2Fcockroach%2Fcockroach-certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=%2Fcockroach%2Fcockroach-certs%2Fca.crt&user=root
-{{ else if eq .Values.database "infinispan" }}
-    - name: storage-hotrod-host
-      value: infinispan
-    - name: storage-hotrod-port
-      value: '11222'
-    - name: storage-hotrod-username
-      value: admin
-    - name: storage-hotrod-password
-      value: admin
-{{ else if eq .Values.database "mixed" }}
-    # in the mixed setup we need to set both hotrod and postgres config options
-    - name: db
-      value: postgres
-    - name: db-url
-      value: jdbc:postgresql://postgres:5432/keycloak
+{{ end }}
+{{ if or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan") }}
     - name: storage-hotrod-host
       value: infinispan
     - name: storage-hotrod-port
@@ -64,7 +51,7 @@ spec:
     - name: spi-public-key-cache-infinispan-enabled
       value: 'false'
 {{ end }}
-{{ if eq .Values.storage "mixed" }}
+{{ if eq .Values.storage "jpa+hotrod" }}
     # in the mixed setup we set storage to jpa and override user sessions, auth sessions, single-use objects, and login failures to use hotrod
     - name: storage
       value: jpa
@@ -188,7 +175,7 @@ spec:
               - containerPort: 8787
                 protocol: TCP
                 name: jvmdebug
-            resources: 
+            resources:
               requests:
                 cpu: "{{ .Values.cpuRequests }}"
                 memory: "{{ .Values.memoryRequestsMB }}M"

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -33,6 +33,20 @@ spec:
       value: admin
     - name: storage-hotrod-password
       value: admin
+{{ else if eq .Values.database "mixed" }}
+    # in the mixed setup we need to set both hotrod and postgres config options
+    - name: db
+      value: postgres
+    - name: db-url
+      value: jdbc:postgresql://postgres:5432/keycloak
+    - name: storage-hotrod-host
+      value: infinispan
+    - name: storage-hotrod-port
+      value: '11222'
+    - name: storage-hotrod-username
+      value: admin
+    - name: storage-hotrod-password
+      value: admin
 {{ end }}
     - name: db-pool-min-size
       value: {{ quote .Values.dbPoolMinSize }}
@@ -50,7 +64,21 @@ spec:
     - name: spi-public-key-cache-infinispan-enabled
       value: 'false'
 {{ end }}
-{{ if ne .Values.storage "" }}
+{{ if eq .Values.storage "mixed" }}
+    # in the mixed setup we set storage to jpa and override user sessions, auth sessions, single-use objects, and login failures to use hotrod
+    - name: storage
+      value: jpa
+    - name: storage-area-auth-session
+      value: hotrod
+    - name: storage-area-user-session
+      value: hotrod
+    - name: storage-area-single-use-object
+      value: hotrod
+    - name: storage-area-login-failure
+      value: hotrod
+    - name: storage-deployment-state-version-seed
+      value: some-secret-seed
+{{ else if ne .Values.storage "" }}
     - name: storage
       value: {{ quote .Values.storage }}
     # this might eventually be set automatically by the operator
@@ -105,6 +133,9 @@ spec:
             imagePullPolicy: Never
 {{ end }}
             env:
+              # arjuna needs access to a writable directory to write temporary files
+              - name: QUARKUS_TRANSACTION_MANAGER_OBJECT_STORE_DIRECTORY
+                value: /tmp
 {{ if .Values.otel }}
               # https://github.com/open-telemetry/opentelemetry-java-instrumentation
               # https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md

--- a/provision/minikube/keycloak/templates/postgres/postgres-deployment.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -31,6 +31,8 @@ spec:
               value: keycloak
           image: postgres:13.2
           args:
+            # default of max_prepared_transactions is 0, and this setting should match the number of active connections
+            # so that running Quarkus with JTA and more than one data store can prepare transactions.
             - -c
             - max_prepared_transactions=100
           imagePullPolicy: Always

--- a/provision/minikube/keycloak/templates/postgres/postgres-deployment.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -30,6 +30,9 @@ spec:
             - name: POSTGRES_DB
               value: keycloak
           image: postgres:13.2
+          args:
+            - -c
+            - max_prepared_transactions=100
           imagePullPolicy: Always
           startupProbe:
             tcpSocket:

--- a/provision/minikube/keycloak/templates/postgres/postgres-exporter-configmap.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-exporter-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
 {{ if .Values.monitoring }}
 apiVersion: v1
 kind: ConfigMap

--- a/provision/minikube/keycloak/templates/postgres/postgres-exporter-configmap.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-exporter-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
 {{ if .Values.monitoring }}
 apiVersion: v1
 kind: ConfigMap

--- a/provision/minikube/keycloak/templates/postgres/postgres-exporter.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-exporter.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
 {{ if .Values.monitoring }}
 ---
 apiVersion: apps/v1

--- a/provision/minikube/keycloak/templates/postgres/postgres-exporter.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-exporter.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
 {{ if .Values.monitoring }}
 ---
 apiVersion: apps/v1

--- a/provision/minikube/keycloak/templates/postgres/postgres-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/postgres/postgres-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/postgres/postgres-service.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-service.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
 ---
 apiVersion: v1
 kind: Service

--- a/provision/minikube/keycloak/templates/postgres/postgres-service.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-service.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
 ---
 apiVersion: v1
 kind: Service

--- a/provision/minikube/keycloak/templates/sqlpad.yaml
+++ b/provision/minikube/keycloak/templates/sqlpad.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "cockroach-single") (eq .Values.database "cockroach-operator") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "cockroach-single") (eq .Values.database "cockroach-operator") (eq .Values.database "mixed") }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -35,7 +35,7 @@ spec:
               value: warn
             - name: SQLPAD_SEED_DATA_PATH
               value: /etc/sqlpad/seed-data
-{{ if eq .Values.database "postgres" }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed" ) }}
             - name: SQLPAD_CONNECTIONS__pgdemo__name
               value: PostgresSQL Keycloak
             - name: SQLPAD_CONNECTIONS__pgdemo__port

--- a/provision/minikube/keycloak/templates/sqlpad.yaml
+++ b/provision/minikube/keycloak/templates/sqlpad.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "cockroach-single") (eq .Values.database "cockroach-operator") (eq .Values.database "mixed") }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "cockroach-single") (eq .Values.database "cockroach-operator") (eq .Values.database "postgres+infinispan") }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -35,7 +35,7 @@ spec:
               value: warn
             - name: SQLPAD_SEED_DATA_PATH
               value: /etc/sqlpad/seed-data
-{{ if or (eq .Values.database "postgres") (eq .Values.database "mixed" ) }}
+{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan" ) }}
             - name: SQLPAD_CONNECTIONS__pgdemo__name
               value: PostgresSQL Keycloak
             - name: SQLPAD_CONNECTIONS__pgdemo__port


### PR DESCRIPTION
This introduces a mixed setup that mirrors what we have in the Legacy store: auth sessions, user sessions, login failures, and single use objects in hotrod, rest on JPA.

For documentation purposes, I'm adding some info about changes we had to make to be able to run this scenario.

1- In the postgres deployment, we've added an arg to enable prepared transactions, which are disabled by default. This is required by Arjuna when it is attempting to coordinate the transactions involving the two stores. So this change:

```
          args:
            - -c
            - max_prepared_transactions=100
```
prevents the Arjuna exception:

```
2023-03-22 09:54:22,744 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-6) Uncaught server error: java.lang.RuntimeException: javax.transaction.HeuristicMixedException
	at org.keycloak.transaction.JtaTransactionWrapper.handleException(JtaTransactionWrapper.java:78)
	at org.keycloak.transaction.JtaTransactionWrapper.commit(JtaTransactionWrapper.java:92)
. . . 
	Caused by: org.postgresql.util.PSQLException: ERROR: prepared transactions are disabled
  Hint: Set max_prepared_transactions to a nonzero value.
		at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
		at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366)
		at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356)
```

2- In `keycloak.yaml`, there's a new env variable that specifies a writable directory that can be used by Arjuna to write files while it is coordinating the transactions:

```
              # arjuna needs access to a writable directory to write temporary files
              - name: QUARKUS_TRANSACTION_MANAGER_OBJECT_STORE_DIRECTORY
                value: /tmp
```

prevents the error

```
"message": "ARJUNA012225: FileSystemStore::setupStore - cannot access root of object store: ObjectStore/ShadowNoFileLockStore/defaultStore/",
```
