### PR TITLE
updating docs to support kvm2 and java as pre-req installations

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/customizing-deployment.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/customizing-deployment.adoc
@@ -148,7 +148,7 @@ Default value: `1`
 KC_CPU_LIMITS::
 Sets CPU limits per Keycloak pod.
 +
-Default value: `1`
+Default value: `4`
 +
 The value must adhere to the https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu[Kubernetes CPU units] format.
 

--- a/doc/kubernetes/modules/ROOT/pages/installation.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/installation.adoc
@@ -13,6 +13,7 @@ Each linked page contains an installation description and a command to verify th
 +
 --
 * xref:prerequisite/prerequisite-minikube.adoc[minikube]
+* 100 GB of free disk space (64 GB is the virtual disk of minikube)
 * xref:prerequisite/prerequisite-helm.adoc[Helm]
 * xref:prerequisite/prerequisite-kubectl.adoc[kubectl]
 * xref:prerequisite/prerequisite-task.adoc[task]

--- a/doc/kubernetes/modules/ROOT/pages/installation.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/installation.adoc
@@ -5,7 +5,9 @@
 * A network downstream speed of at least 10 Mbps to allow for a timely download of all necessary images and containers.
 A slower downstream might lead to timeouts and pods might not start.
 
-* 4 CPU cores, 8 GB of free RAM and free disk space of ~20 GB to run the minikube instance with Keycloak and observability tools inside.
+* 4 CPU cores, 8 GB of free RAM and free disk space of ~100 GB to run the minikube instance with Keycloak and observability tools inside.
++
+If you have less available disk space, change the minikube disk size in `rebuild.sh` from 64 GB to a lower value.
 
 * The following tools need to be installed on the local machine.
 +
@@ -13,7 +15,6 @@ Each linked page contains an installation description and a command to verify th
 +
 --
 * xref:prerequisite/prerequisite-minikube.adoc[minikube]
-* 100 GB of free disk space (64 GB is the virtual disk of minikube)
 * xref:prerequisite/prerequisite-helm.adoc[Helm]
 * xref:prerequisite/prerequisite-kubectl.adoc[kubectl]
 * xref:prerequisite/prerequisite-task.adoc[task]

--- a/doc/kubernetes/modules/ROOT/pages/installation.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/installation.adoc
@@ -17,6 +17,7 @@ Each linked page contains an installation description and a command to verify th
 * xref:prerequisite/prerequisite-kubectl.adoc[kubectl]
 * xref:prerequisite/prerequisite-task.adoc[task]
 * xref:prerequisite/prerequisite-yq.adoc[yq]
+* xref:prerequisite/prerequisite-java.adoc[Java]
 --
 
 After all tools are installed, continue with the next section.

--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-java.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-java.adoc
@@ -1,21 +1,23 @@
 = Installing Java as a pre-requisite
 :navtitle: Installing Java
-:description: java is a pre-requisite for scripting the automation for Keycloak Benchmark..
+:description: Java 11 or later is a pre-requisite for scripting the automation for Keycloak Benchmark.
 
 {description}
-It needs to be installed before the  xref:installation.adoc[] can begin.
+It needs to be installed before the xref:installation.adoc[] can begin.
 
 == Installing Java
 
-There are quite a few variants of Java which you can download for free and install it. To keep it simple, lets focus on the OpenJDK java installation.
+There are quite a few variants of Java which you can download for free and install it.
+This guide focuses on the OpenJDK java installation on Linux.
 
 You can find detailed steps to install Java based on your OS in the https://openjdk.org/install/[installation docs].
 
-Assuming you have installed the OpenJDK in `/usr/lib/jvm`, lets create a `JAVA_HOME` variable pointing to the directory of the specific JDK version you wanted to use with the provisioning automation.
+Assuming you have installed the OpenJDK on Linux in `/usr/lib/jvm`, create a `JAVA_HOME` variable pointing to the directory of the specific JDK version you wanted to use with the provisioning automation.
+If you do not set up this environment variable, the installation will try to find a JDK on the path.
 
 [source, bash]
 ----
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.18.0.10-2.el8_7.x86_64/
+export JAVA_HOME=/usr/lib/jvm/java-11
 ----
 
 == Verifying the installation of Java
@@ -27,14 +29,14 @@ echo $JAVA_HOME
 
 Should print an output like:
 ----
-/usr/lib/jvm/java-11-openjdk-11.0.18.0.10-2.el8_7.x86_64
+/usr/lib/jvm/java-11
 ----
 
 
 The command to verify if Java is installed properly on your host:
 [source,bash]
 ----
-java --version
+$JAVA_HOME/bin/java --version
 ----
 
 Should print an output like:

--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-java.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-java.adoc
@@ -1,0 +1,45 @@
+= Installing Java as a pre-requisite
+:navtitle: Installing Java
+:description: java is a pre-requisite for scripting the automation for Keycloak Benchmark..
+
+{description}
+It needs to be installed before the  xref:installation.adoc[] can begin.
+
+== Installing Java
+
+There are quite a few variants of Java which you can download for free and install it. To keep it simple, lets focus on the OpenJDK java installation.
+
+You can find detailed steps to install Java based on your OS in the https://openjdk.org/install/[installation docs].
+
+Assuming you have installed the OpenJDK in `/usr/lib/jvm`, lets create a `JAVA_HOME` variable pointing to the directory of the specific JDK version you wanted to use with the provisioning automation.
+
+[source, bash]
+----
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.18.0.10-2.el8_7.x86_64/
+----
+
+== Verifying the installation of Java
+The command to verify if JAVA_HOME is set properly:
+[source, bash]
+----
+echo $JAVA_HOME
+----
+
+Should print an output like:
+----
+/usr/lib/jvm/java-11-openjdk-11.0.18.0.10-2.el8_7.x86_64
+----
+
+
+The command to verify if Java is installed properly on your host:
+[source,bash]
+----
+java --version
+----
+
+Should print an output like:
+----
+openjdk 11.0.18 2023-01-17 LTS
+OpenJDK Runtime Environment (Red_Hat-11.0.18.0.10-2.el8_7) (build 11.0.18+10-LTS)
+OpenJDK 64-Bit Server VM (Red_Hat-11.0.18.0.10-2.el8_7) (build 11.0.18+10-LTS, mixed mode, sharing)
+----

--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-minikube.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-minikube.adoc
@@ -18,7 +18,34 @@ Add the following snippet to the file `~/.bashrc` to allow auto-completion of co
 source <(minikube completion bash)
 ----
 
-== Verifying the installation of minkube
+The choice of Virtual Machine manger the user would install is probably dependent on the developer host Operating System. Below are the VM drivers which are tested and proven to be working without issue for the respective host OS.
+
+=== Linux Host
+KVM or Kernel-based Virtual Machine is a full virtualization solution for Linux on x86 hardware containing virtualization extensions. To learn more about it and its relevance to minikube, you can read the https://minikube.sigs.k8s.io/docs/drivers/kvm2/[docs].
+
+Please take a note that the linux User needs to be added to the `libvirt` group using the below command.
+
+
+[source,bash]
+----
+sudo usermod -aG libvirt $USER
+----
+
+Optionally you can use the below command to verify if the libvirt group exists and is updated with the user
+
+The command:
+[source,bash]
+----
+getent group libvirt
+----
+
+Should print an output like:
+
+----
+libvirt:x:981:johndoe
+----
+
+== Verifying the installation of minikube
 
 The command:
 

--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-yq.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-yq.adoc
@@ -7,7 +7,7 @@ It needs to be installed before the  xref:installation.adoc[] can begin.
 
 == Installing yq
 
-The recommended installation is to download the latest binary from the task GitHub releases and put it into the user's `~/bin` directory.
+The recommended installation is to download the latest binary from the yq GitHub releases and put it into the user's `~/bin` directory.
 
 The installation guide is available in the https://github.com/mikefarah/yq/#install[yq installation guide].
 

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -233,12 +233,12 @@ tasks:
     run: once
     cmds:
       # download maven wrapper to avoid concurrent downloads with can break the build
-      - ./mvnw -v
+      - bash -c "./mvnw -v"
     preconditions:
       # Either JAVA_HOME is set and points to a valid JDK folder with 'bin/java' in it,
       # or javac is found on the path which indicates a Java SDK to be installed.
       # This logic is similar to the one present in 'mvnw'
-      - sh: "{ [ ! -z ${JAVA_HOME} ] && [ -x '${JAVA_HOME}/bin/java' ]; } || [ $(which javac) ]"
+      - sh: "{ [ ! -z ${JAVA_HOME} ] && [ -x '${JAVA_HOME}/bin/java' ]; } || [ $(which javac) ] || [ $(uname) != Linux ]"
         msg: "Please set the JAVA_HOME env variable to point to a Java SDK."
     sources:
       - ../../.mvn/wrapper/maven-wrapper.properties
@@ -252,7 +252,7 @@ tasks:
       - mvnw
     dir: ../..
     cmds:
-      - ./mvnw -B -am -pl dataset clean install -DskipTests
+      - bash -c "./mvnw -B -am -pl dataset clean install -DskipTests"
     sources:
       - ../../pom.xml
       - dataset/pom.xml

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -235,8 +235,11 @@ tasks:
       # download maven wrapper to avoid concurrent downloads with can break the build
       - ./mvnw -v
     preconditions:
-      - sh: "[ ! -z ${JAVA_HOME} ]"
-        msg: "Please properly set your JAVA_HOME env variable."
+      # Either JAVA_HOME is set and points to a valid JDK folder with 'bin/java' in it,
+      # or javac is found on the path which indicates a Java SDK to be installed.
+      # This logic is similar to the one present in 'mvnw'
+      - sh: "{ [ ! -z ${JAVA_HOME} ] && [ -x '${JAVA_HOME}/bin/java' ]; } || [ $(which javac) ]"
+        msg: "Please set the JAVA_HOME env variable to point to a Java SDK."
     sources:
       - ../../.mvn/wrapper/maven-wrapper.properties
       - .task/subtask-{{.TASK}}.yaml

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -19,7 +19,7 @@ vars:
   KC_CONTAINER_IMAGE: '{{default "" .KC_CONTAINER_IMAGE}}'
   KC_INSTANCES: '{{default "1" .KC_INSTANCES}}'
   KC_CPU_REQUESTS: '{{default "0" .KC_CPU_REQUESTS}}'
-  KC_CPU_LIMITS: '{{default "1" .KC_CPU_LIMITS}}'
+  KC_CPU_LIMITS: '{{default "4" .KC_CPU_LIMITS}}'
   KC_MEMORY_REQUESTS_MB: '{{default "1024" .KC_MEMORY_REQUESTS_MB}}'
   KC_MEMORY_LIMITS_MB: '{{default "1024" .KC_MEMORY_LIMITS_MB}}'
   KC_HEAP_INIT_MB: '{{default "64" .KC_HEAP_INIT_MB}}'

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -235,7 +235,7 @@ tasks:
       # download maven wrapper to avoid concurrent downloads with can break the build
       - ./mvnw -v
     preconditions:
-      - sh: "[ -z ${JAVA_HOME} ]"
+      - sh: "[ ! -z ${JAVA_HOME} ]"
         msg: "Please properly set your JAVA_HOME env variable."
     sources:
       - ../../.mvn/wrapper/maven-wrapper.properties

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -234,6 +234,9 @@ tasks:
     cmds:
       # download maven wrapper to avoid concurrent downloads with can break the build
       - ./mvnw -v
+    preconditions:
+      - sh: "[ -z ${JAVA_HOME} ]"
+        msg: "Please properly set your JAVA_HOME env variable."
     sources:
       - ../../.mvn/wrapper/maven-wrapper.properties
       - .task/subtask-{{.TASK}}.yaml

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -19,7 +19,7 @@ disableCaches: false
 keycloakImage: ''
 instances: 1
 cpuRequests: 0
-cpuLimits: 1
+cpuLimits: 4
 memoryRequestsMB: 1024
 memoryLimitsMB: 1024
 heapInitMB: 64

--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 # set -x
 set -e
+
+#prerequisite checks
+if [ "$(egrep -c 'vmx|svm' /proc/cpuinfo)" -ge 0 ]; then
+  echo "PRE-REQ CHECK PASSED: Virtualization is enabled on the host machine, its safe to proceed."
+else
+  echo >&2 "PRE-REQ CHECK FAILED: Virtualization is not enabled properly on the host machine. Please check the installation docs."
+  exit 1
+fi
+
+if [ "$(getent group libvirt | grep -c $USER)" -ge 0 ]; then
+  echo "PRE-REQ CHECK PASSED: User is found in the libvirt group."
+else
+  echo >&2 "PRE-REQ CHECK FAILED: User is not found in the libvirt group. Please check the installation docs."
+  exit 1
+fi
+
 if [ "$GITHUB_ACTIONS" == "" ]; then
   minikube delete
   minikube config set memory 8192

--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -10,11 +10,14 @@ else
   exit 1
 fi
 
-if [ "$(getent group libvirt | grep -c $USER)" -ge 0 ]; then
-  echo "PRE-REQ CHECK PASSED: User is found in the libvirt group."
-else
-  echo >&2 "PRE-REQ CHECK FAILED: User is not found in the libvirt group. Please check the installation docs."
-  exit 1
+# this test is valid only on Linux, and would fail on Windows
+if [ "$(uname)" == "Linux" ]; then
+  if [ "$(getent group libvirt | grep -c $USER)" -ge 0 ]; then
+    echo "PRE-REQ CHECK PASSED: User is found in the libvirt group."
+  else
+    echo >&2 "PRE-REQ CHECK FAILED: User is not found in the libvirt group. Please check the installation docs."
+    exit 1
+  fi
 fi
 
 if [ "$GITHUB_ACTIONS" == "" ]; then

--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -3,11 +3,14 @@
 set -e
 
 #prerequisite checks
-if [ "$(egrep -c 'vmx|svm' /proc/cpuinfo)" -ge 0 ]; then
-  echo "PRE-REQ CHECK PASSED: Virtualization is enabled on the host machine, its safe to proceed."
-else
-  echo >&2 "PRE-REQ CHECK FAILED: Virtualization is not enabled properly on the host machine. Please check the installation docs."
-  exit 1
+#this test is valid only on Linux, and would fail on Windows, MacOS
+if [ "$(uname)" == "Linux" ]; then
+ if [ "$(egrep -c 'vmx|svm' /proc/cpuinfo)" -ge 0 ]; then
+   echo "PRE-REQ CHECK PASSED: Virtualization is enabled on the host machine, its safe to proceed."
+ else
+   echo >&2 "PRE-REQ CHECK FAILED: Virtualization is not enabled properly on the host machine. Please check the installation docs."
+   exit 1
+ fi
 fi
 
 # this test is valid only on Linux, and would fail on Windows


### PR DESCRIPTION
- Updated https://www.keycloak.org/keycloak-benchmark/kubernetes-guide/latest/prerequisite/prerequisite-minikube with a Linux section explaining that KVM2 is necessary, explained how to set it up for a Linux host OS and a small check to verify that.
- Java is added as a prerequisite https://www.keycloak.org/keycloak-benchmark/kubernetes-guide/latest/installation, with steps for installation of OpenJDK and create a JAVA_HOME variable for specific JDK version and step to verify if the installation was successful.

Additionally added couple of checks to ensure the host is vetted for
- Virtualization and the user is associated with the libvirt group
- Validate if JAVA_HOME variable is set properly

-----
Fixes #300 