### PR TITLE
Porting changes for supporting Dataset and Gatling User entities creation on OCP

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/openshift.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/openshift.adoc
@@ -14,7 +14,7 @@ WARNING: OpenShift must not be accessible from the Internet, as this setup opens
 * xref:prerequisite/prerequisite-kubectl.adoc[kubectl]
 * xref:prerequisite/prerequisite-task.adoc[task]
 * xref:prerequisite/prerequisite-yq.adoc[yq]
-// * xref:prerequisite/prerequisite-java.adoc[Java]
+* xref:prerequisite/prerequisite-java.adoc[Java]
 
 Verify that the setup works using `kubectl get pods -A`.
 
@@ -25,8 +25,6 @@ At the moment, the following is known not to work on OpenShift:
 
 sqlpad:: Container requires a root user.
 cryostat:: OpenShift instance needs to have persistent storage enabled for this to work.
-dataset provider:: This is currently not automatically built and installed as part of running the `task` command.
-gatling client setup:: This is currently not automatically built and installed as part of running the `task` command.
 monitoring:: The OpenShift installation will eventually use the monitoring provided with OpenShift.
 
 == Installing Keycloak on OpenShift

--- a/provision/common/Taskfile.yaml
+++ b/provision/common/Taskfile.yaml
@@ -86,3 +86,95 @@ tasks:
       - test "{{.KC_METASPACE_INIT_MB}}" == "$(cat .task/var-KC_METASPACE_INIT_MB)"
       - test "{{.KC_METASPACE_MAX_MB}}" == "$(cat .task/var-KC_METASPACE_MAX_MB)"
       - test "{{.KC_CUSTOM_INFINISPAN_CONFIG}}" == "$(cat .task/var-KC_CUSTOM_INFINISPAN_CONFIG)"
+
+  mvnw:
+    dir: ../..
+    run: once
+    cmds:
+      # download maven wrapper to avoid concurrent downloads with can break the build
+      - bash -c "./mvnw -v"
+    preconditions:
+      # Either JAVA_HOME is set and points to a valid JDK folder with 'bin/java' in it,
+      # or javac is found on the path which indicates a Java SDK to be installed.
+      # This logic is similar to the one present in 'mvnw'
+      - sh: "{ [ ! -z ${JAVA_HOME} ] && [ -x '${JAVA_HOME}/bin/java' ]; } || [ $(which javac) ] || [ $(uname) != Linux ]"
+        msg: "Please set the JAVA_HOME env variable to point to a Java SDK."
+    sources:
+      - ../../.mvn/wrapper/maven-wrapper.properties
+      - .task/subtask-{{.TASK}}.yaml
+    generates:
+      - ../../.mvn/wrapper/maven-wrapper.jar
+
+  dataset:
+    deps:
+      - split
+      - mvnw
+    dir: ../..
+    cmds:
+      - bash -c "./mvnw -B -am -pl dataset clean install -DskipTests"
+    sources:
+      - ../../pom.xml
+      - dataset/pom.xml
+      - dataset/src/**/*.*
+      - .task/subtask-{{.TASK}}.yaml
+    generates:
+      - dataset/target/keycloak-benchmark-dataset-*.jar
+
+  datasetprovider:
+    deps:
+      - dataset
+      - split
+    cmds:
+      - mkdir -p keycloak/providers
+      - rm -f keycloak/providers/keycloak-benchmark-dataset-*.jar
+      - cp ../../dataset/target/keycloak-benchmark-dataset-*.jar keycloak/providers
+    sources:
+      - ../../dataset/target/keycloak-benchmark-dataset-*.jar
+      - .task/subtask-{{.TASK}}.yaml
+    status:
+      - test -f keycloak/providers/keycloak-benchmark-dataset-*.jar
+
+  keycloak-cli-download:
+    dir: ..
+    cmds:
+      - mkdir -p keycloak-cli
+      - rm -f keycloak-cli/*.zip
+      - >
+        curl -L -f https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.zip -o keycloak-cli/keycloak.zip
+    status:
+      - find keycloak-cli/keycloak.zip -mtime +1 -exec false {} +
+    sources:
+      - .task/subtask-{{.TASK}}.yaml
+
+  keycloak-cli-unzip:
+    deps:
+      - keycloak-cli-download
+      - split
+    dir: ..
+    cmds:
+      # remove temporary folders to be extra safe
+      - rm -rf keycloak-cli/keycloak-999.0.0-SNAPSHOT
+      - rm -rf keycloak-cli/keycloak
+      - unzip -o -q keycloak-cli/keycloak.zip -d keycloak-cli
+      # the output folder depends on the version we're about to unpack
+      - mv keycloak-cli/keycloak-999.0.0-SNAPSHOT keycloak-cli/keycloak || mv keycloak-cli/keycloak-19.0.1 keycloak-cli/keycloak
+    sources:
+      - keycloak-cli/keycloak.zip
+      - minikube/.task/subtask-{{.TASK}}.yaml
+
+  tlsdisableagent:
+    deps:
+      - split
+      - mvnw
+    dir: ../tlsdisableagent
+    cmds:
+      - bash -c ./buildtlsagent.sh
+    sources:
+      - ../tlsdisableagent/hooks/*.*
+      - ../tlsdisableagent/buildtlsagent.sh
+      - ../tlsdisableagent/tlscheckdisable.txt
+      - ../tlsdisableagent/java-instrumentation-tool/src/**/*.*
+      - ../tlsdisableagent/java-instrumentation-tool/pom.xml
+      - .task/subtask-{{.TASK}}.yaml
+    generates:
+      - ../tlsdisableagent/tlscheckdisable-agent.jar

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -154,53 +154,6 @@ tasks:
       - promtail.yaml
       - .task/subtask-{{.TASK}}.yaml
 
-  mvnw:
-    dir: ../..
-    run: once
-    cmds:
-      # download maven wrapper to avoid concurrent downloads with can break the build
-      - bash -c "./mvnw -v"
-    preconditions:
-      # Either JAVA_HOME is set and points to a valid JDK folder with 'bin/java' in it,
-      # or javac is found on the path which indicates a Java SDK to be installed.
-      # This logic is similar to the one present in 'mvnw'
-      - sh: "{ [ ! -z ${JAVA_HOME} ] && [ -x '${JAVA_HOME}/bin/java' ]; } || [ $(which javac) ] || [ $(uname) != Linux ]"
-        msg: "Please set the JAVA_HOME env variable to point to a Java SDK."
-    sources:
-      - ../../.mvn/wrapper/maven-wrapper.properties
-      - .task/subtask-{{.TASK}}.yaml
-    generates:
-      - ../../.mvn/wrapper/maven-wrapper.jar
-
-  dataset:
-    deps:
-      - common:split
-      - mvnw
-    dir: ../..
-    cmds:
-      - bash -c "./mvnw -B -am -pl dataset clean install -DskipTests"
-    sources:
-      - ../../pom.xml
-      - dataset/pom.xml
-      - dataset/src/**/*.*
-      - .task/subtask-{{.TASK}}.yaml
-    generates:
-      - dataset/target/keycloak-benchmark-dataset-*.jar
-
-  datasetprovider:
-    deps:
-      - dataset
-      - common:split
-    cmds:
-      - mkdir -p keycloak/providers
-      - rm -f keycloak/providers/keycloak-benchmark-dataset-*.jar
-      - cp ../../dataset/target/keycloak-benchmark-dataset-*.jar keycloak/providers
-    sources:
-      - ../../dataset/target/keycloak-benchmark-dataset-*.jar
-      - .task/subtask-{{.TASK}}.yaml
-    status:
-      - test -f keycloak/providers/keycloak-benchmark-dataset-*.jar
-
   dataset-import:
     deps:
       - gatlinguser
@@ -208,55 +161,10 @@ tasks:
       - bash -c "../../dataset/dataset-import.sh {{.CLI_ARGS}}"
     silent: true
 
-  tlsdisableagent:
-    deps:
-      - common:split
-      - mvnw
-    dir: ../tlsdisableagent
-    cmds:
-      - bash -c ./buildtlsagent.sh
-    sources:
-      - ../tlsdisableagent/hooks/*.*
-      - ../tlsdisableagent/buildtlsagent.sh
-      - ../tlsdisableagent/tlscheckdisable.txt
-      - ../tlsdisableagent/java-instrumentation-tool/src/**/*.*
-      - ../tlsdisableagent/java-instrumentation-tool/pom.xml
-      - .task/subtask-{{.TASK}}.yaml
-    generates:
-      - ../tlsdisableagent/tlscheckdisable-agent.jar
-
-  keycloak-cli-download:
-    dir: ..
-    cmds:
-      - mkdir -p keycloak-cli
-      - rm -f keycloak-cli/*.zip
-      - >
-        curl -L -f https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.zip -o keycloak-cli/keycloak.zip
-    status:
-      - find keycloak-cli/keycloak.zip -mtime +1 -exec false {} +
-    sources:
-      - .task/subtask-{{.TASK}}.yaml
-
-  keycloak-cli-unzip:
-    deps:
-      - keycloak-cli-download
-      - common:split
-    dir: ..
-    cmds:
-      # remove temporary folders to be extra safe
-      - rm -rf keycloak-cli/keycloak-999.0.0-SNAPSHOT
-      - rm -rf keycloak-cli/keycloak
-      - unzip -o -q keycloak-cli/keycloak.zip -d keycloak-cli
-      # the output folder depends on the version we're about to unpack
-      - mv keycloak-cli/keycloak-999.0.0-SNAPSHOT keycloak-cli/keycloak || mv keycloak-cli/keycloak-19.0.1 keycloak-cli/keycloak
-    sources:
-      - keycloak-cli/keycloak.zip
-      - minikube/.task/subtask-{{.TASK}}.yaml
-
   gatlinguser:
     deps:
-      - keycloak-cli-unzip
-      - tlsdisableagent
+      - common:keycloak-cli-unzip
+      - common:tlsdisableagent
       - keycloak
       - common:split
       - ipchange
@@ -278,7 +186,7 @@ tasks:
   keycloak:
     deps:
       - monitoring
-      - datasetprovider
+      - common:datasetprovider
       - common:split
       - ipchange
       - jaeger

--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -15,7 +15,7 @@ includes:
 tasks:
   default:
     deps:
-      - keycloak
+      - gatlinguser
     cmds:
       - echo Keycloak is ready for load testing!
       - bash -c ./isup.sh
@@ -30,6 +30,8 @@ tasks:
       - bash -c "kubectl delete deployment/keycloak-operator -n keycloak || exit 0"
       # discard status of keycloak to force redeployment
       - rm -f .task/checksum/keycloak
+      # discard status of gatling user to force redeployment
+      - rm -f .task/checksum/gatlinguser
       - task: default
 
   openshift-env:
@@ -45,8 +47,42 @@ tasks:
     status:
       - test "{{.KC_HOSTNAME_SUFFIX}}" == "$(cat .task/var-KC_HOSTNAME_SUFFIX)"
 
+  dataset-import:
+    deps:
+      - gatlinguser
+    cmds:
+      - bash -c "../../dataset/dataset-import.sh -l https://keycloak.{{.KC_HOSTNAME_SUFFIX}}/realms/master/dataset {{.CLI_ARGS}}"
+    silent: true
+
+  gatlinguser:
+    deps:
+      - common:keycloak-cli-unzip
+      - common:tlsdisableagent
+      - keycloak
+      - common:split
+    env:
+      KC_OPTS: "-javaagent:../tlsdisableagent/tlscheckdisable-agent.jar"
+      KEYCLOAK_HOME: "../keycloak-cli/keycloak"
+    cmds:
+      - bash -c ./isup.sh
+      - >
+        bash -c '
+        if [ "{{.KC_HOSTNAME_SUFFIX}}" != "" ];
+          then ../keycloak-cli/keycloak/bin/kcadm.sh config credentials --server https://keycloak.{{.KC_HOSTNAME_SUFFIX}}/ --realm master --user admin --password admin;
+          else echo -e "KC_HOSTNAME_SUFFIX value is not set properly";
+        fi'
+      - bash -c "../../benchmark/src/main/content/bin/initialize-benchmark-entities.sh -r test-realm -d"
+    sources:
+      - ../../benchmark/src/main/content/bin/initialize-benchmark-entities.sh
+      - .task/subtask-{{.TASK}}.yaml
+      # if keycloak's database deployment changes, this restarts the DB and the Gatling user needs to be re-created
+      - .task/status-keycloak-db.json
+      - .task/var-KC_STORAGE
+      - .task/var-KC_DATABASE
+
   keycloak:
     deps:
+      - common:datasetprovider
       - common:split
       - common:env
       - openshift-env


### PR DESCRIPTION
Fixes #314 

- Added the support to create the needed service account enabled client, test-realm and users to start a benchmark against the Openshift cluster based Keycloak instance.
- Akin to the above point, to be able to deploy dataset module to the Openshift cluster based Keycloak instance and create needed datasets for various entities.

Even though the dataset module is ported, I am observing an issue @ahus1 with the keycloak/providers directory unable to be mounted to `/opt/keycloak/providers` thus not able to run the dataset-import.sh script to create the entities, I might need some help on this.