### PR TITLE
Remove unnecessary exports

### DIFF
--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -196,8 +196,6 @@ tasks:
       - bash -c 'kubectl get pods -n {{.KC_NAMESPACE_PREFIX}}keycloak | grep -E "(BackOff|Error|ErrImageNeverPull|InvalidImageName)" | tr -s " " | cut -d" " -f1 | xargs -r -L 1 kubectl delete -n {{.KC_NAMESPACE_PREFIX}}keycloak pod'
       # wait a bit for the operator to pick up the changes
       - bash -c 'sleep 2'
-      - export KC_NAMESPACE_PREFIX={{.KC_NAMESPACE_PREFIX}}
-      - export KC_HOSTNAME_SUFFIX={{.KC_HOSTNAME_SUFFIX}}
       - ./isup.sh
       # remove all no longer used images from minikube to preserve disk space
     sources:


### PR DESCRIPTION
While working on the namespace customization I needed to pass the `KC_NAMESPACE_PREFIX` property to `isup.sh` script. I tried to use export in the `keycloak` task, however, it didn't work, and then I forgot to remove it.

This Pr is to remove it.