### PR TITLE
Automated scheduling of creation of shared ROSA cluster and another end of business reaper 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,6 +27,13 @@
    1. Name of the cluster - the name of the cluster to destroy. Default value is `gh-${{ github.repository_owner }}`, this results in `gh-<owner of fork>`.
 4. Wait for the workflow to finish.
 
+## Periodic Jobs
+1. We are managing the creation of shared ROSA clusters' creation and deletion using below workflows.
+   2. `.github/workflows/rosa-cluster-auto-delete-on-schedule.yml`
+   3. `.github/workflows/rosa-cluster-auto-provision-on-schedule.yml`
+4. Optionally you can run the `task keepalive` from provision/openshift directory against your Openshift cluster to keep it alive, from the `rosa-cluster-auto-delete-on-schedule` workflow's delete activity on the defined schedule time.
+
+
 ## Run benchmark
 
 1. Go to repository Actions -> On the left side choose `ROSA Cluster - Run Benchmark`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,9 +29,9 @@
 
 ## Periodic Jobs
 1. We are managing the creation of shared ROSA clusters' creation and deletion using below workflows.
-   2. `.github/workflows/rosa-cluster-auto-delete-on-schedule.yml`
-   3. `.github/workflows/rosa-cluster-auto-provision-on-schedule.yml`
-4. Optionally you can run the `task keepalive` from provision/openshift directory against your Openshift cluster to keep it alive, from the `rosa-cluster-auto-delete-on-schedule` workflow's delete activity on the defined schedule time.
+   1. `.github/workflows/rosa-cluster-auto-delete-on-schedule.yml`
+   2. `.github/workflows/rosa-cluster-auto-provision-on-schedule.yml`
+2. Optionally you can run the `task keepalive` from provision/openshift directory against your Openshift cluster to keep it alive, from the `rosa-cluster-auto-delete-on-schedule` workflow's delete activity on the defined schedule time.
 
 
 ## Run benchmark

--- a/.github/workflows/rosa-cluster-auto-delete-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-delete-on-schedule.yml
@@ -1,0 +1,16 @@
+name: ROSA Scheduled Delete
+
+on:
+  schedule:
+    - cron: '0 19 * * *' # Runs every day at 7 PM UTC.
+
+jobs:
+
+  checkout:
+    name: ROSA Scheduled Delete cluster(s)
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run -R keycloak/keycloak-benchmark rosa-cluster-delete.yml -f deleteAll='yes'
+        if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -1,0 +1,16 @@
+name: ROSA Scheduled Create
+
+on:
+  schedule:
+    - cron: '0 7 * * 1-5' # Runs At 07:00 UTC on every day-of-week from Monday through Friday.
+
+jobs:
+
+  checkout:
+    name: ROSA Scheduled Create cluster
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh workflow run -R keycloak/keycloak-benchmark rosa-cluster-create.yml
+        if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rosa-cluster-delete.yml
+++ b/.github/workflows/rosa-cluster-delete.yml
@@ -6,6 +6,11 @@ on:
       clusterName:
         description: 'Name of the cluster'
         type: text
+      deleteAll:
+        description: 'Delete all clusters'
+        required: true
+        default: 'no'
+        type: text
 jobs:
 
   delete:
@@ -23,8 +28,14 @@ jobs:
           aws-default-region: ${{ vars.AWS_DEFAULT_REGION }}
           rosa-token: ${{ secrets.ROSA_TOKEN }}
 
-      - name: Delete ROSA Cluster
+      - name: Delete a ROSA Cluster
+        if: ${{ inputs.deleteAll == 'no' }}
         run: ./rosa_delete_cluster.sh
         working-directory: provision/aws
         env:
           CLUSTER_NAME: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
+
+      - name: Delete all ROSA Clusters
+        if: ${{ inputs.deleteAll == 'yes' }}
+        run: ./rosa_cluster_reaper.sh
+        working-directory: provision/aws

--- a/provision/aws/rosa_cluster_reaper.sh
+++ b/provision/aws/rosa_cluster_reaper.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e
+
+if [ -f ./.env ]; then
+  source ./.env
+fi
+
+echo "Starting the ROSA cluster reaper at $(date -uIs)"
+
+# Get a list of running ROSA clusters
+CLUSTERS=$(rosa list clusters --output json | jq -r '.[] | select((.state == "ready") or (.state == "pending") or (.state == "waiting") or (.state == "error")) | .name')
+
+if [ -z "$CLUSTERS" ]; then echo "Didn't find any ready state clusters"; exit 1; fi
+
+# Loop through each cluster
+for CLUSTER_NAME in $CLUSTERS; do
+  echo "Checking Cluster: $CLUSTER_NAME"
+  export CLUSTER_NAME=$CLUSTER_NAME
+  #Login to the Openshift Cluster
+  ./rosa_oc_login.sh
+  #Check if the 'keepalive' namespace exists in the specific cluster
+  if oc get projects | grep -q "keepalive"; then
+    echo "keepalive namespace exists in the cluster $CLUSTER_NAME., skipping deleting it."
+  else
+    echo "keepalive namespace doesn't exist in the cluster $CLUSTER_NAME., deleting it."
+    #Delete the Individual Cluster
+    ./rosa_delete_cluster.sh
+  fi
+done
+
+echo "Finished reaping all possible clusters at $(date -uIs)"
+
+
+

--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -145,6 +145,14 @@ tasks:
       - monitoring/**/*.*
       - .task/subtask-{{.TASK}}.yaml
 
+  keepalive:
+    deps:
+      - openshift-env
+    cmds:
+      - kubectl create namespace keepalive
+    sources:
+      - .task/subtask-{{.TASK}}.yaml
+
   keycloak:
     deps:
       - common:datasetprovider


### PR DESCRIPTION
Adding two new workflow files:

- rosa-cluster-auto-provision-on-schedule
- rosa-cluster-auto-delete-on-schedule

Setting static values for cluster creation, as below:

- CLUSTER_NAME: shared-crossdc
- COMPUTE_MACHINE_TYPE: m5.xlarge
- MULTI_AZ: false
- REPLICAS: 2

and a Rosa cluster reaper scripts, which takes input of a list of "ready" state clusters

- rosa_cluster_reaper.sh

My first attempt at GH workflow's so if something's amiss, please correct it :) 

Open question, there could be cluster's which could be in other `states` other than `ready`, do we want any alert on it ? Another question is, do we want any email notification after the job is complete, alternative would be to personally tune the GH Workflow notifications to report on this workflow, reducing the email clutter.