### PR TITLE
Avoid node-ports usage in OpenShift

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/installation-openshift.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/installation-openshift.adoc
@@ -73,8 +73,3 @@ The following options are necessary for customizing Keycloak deployment in a way
 `xref:customizing-deployment.adoc#KC_NAMESPACE_PREFIX[KC_NAMESPACE_PREFIX]`:: Allows customizing the namespace name.
 The resulting namespace will be `++${KC_NAMESPACE_PREFIX}++keycloak`.
 By default, the namespace prefix is set to `$(whoami)-`, but it can be customized in `.env` file.
-
-`xref:customizing-deployment.adoc#KC_PORT_OFFSET[KC_PORT_OFFSET]`:: Keycloak deployment contains several services that are exposed via NodePort.
-By default, the port offset is set to `0`.
-When more users use Keycloak benchmark with the same port offset the task execution will fail with the following message: `Invalid value: 3XXXX: provided port is already allocated`, in that case choose different port offset value in the `.env` file.
-

--- a/provision/minikube/keycloak/templates/NOTES.txt
+++ b/provision/minikube/keycloak/templates/NOTES.txt
@@ -10,25 +10,27 @@ sqlpad will be available on http://sqlpad.{{ .Values.hostname }}
 Cryostat will be available on https://cryostat.{{ .Values.hostname }}
 {{ end -}}
 {{ if eq .Values.database "postgres" -}}
+{{ if .Values.nodePortsEnabled }}
 Connect to PostgreSQL on {{ .Values.hostname }}:{{ add 30009 (mul .Values.portOffset 100) }}
   user: keycloak
   password: pass
   JDBC URL: jdbc:postgresql://{{ .Values.hostname }}:{{ add 30009 (mul .Values.portOffset 100) }}/keycloak
+{{ end }}
 {{ else if eq .Values.database "infinispan" -}}
-Connect to Infinispan on {{ .Values.hostname }}:{{ add 30011 (mul .Values.portOffset 100) }}
+Connect to Infinispan {{ if .Values.nodePortsEnabled }}on {{ .Values.hostname }}:{{ add 30011 (mul .Values.portOffset 100) }}{{ end }}
   user: admin
   password: admin
   Console URL: https://infinispan.{{ .Values.hostname }}/
 {{ else if eq .Values.database "cockroach-single" -}}
-Connect to CockroachDB on {{ .Values.hostname }}:{{ add 30010 (mul .Values.portOffset 100) }}
+Connect to CockroachDB {{ if .Values.nodePortsEnabled }}on {{ .Values.hostname }}:{{ add 30010 (mul .Values.portOffset 100) }}{{ end }}
   user: keycloak
   password: pass
   JDBC URL: jdbc:postgresql://{{ .Values.hostname }}:{{ add 30010 (mul .Values.portOffset 100) }}/keycloak
   Console URL: https://cockroach.{{ .Values.hostname }}/
 {{ else if eq .Values.database "cockroach-operator" -}}
-Connect to CockroachDB on {{ .Values.hostname }}:{{ add 30013 (mul .Values.portOffset 100) }}
+Connect to CockroachDB {{ if .Values.nodePortsEnabled }}on {{ .Values.hostname }}:{{ add 30013 (mul .Values.portOffset 100) }}
   JDBC URL: jdbc:postgresql://{{ .Values.hostname }}:{{ add 30013 (mul .Values.portOffset 100) }}/keycloak + TLS files in provision/minikube/crdb/
-  user: root
+  user: root {{ end }}
   Console URL: https://cockroach.{{ .Values.hostname }}/
   user: keycloak
   password: pass

--- a/provision/minikube/keycloak/templates/cockroach-operator/cockroach-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/cockroach-operator/cockroach-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "cockroach-operator" }}
+{{ if and (eq .Values.database "cockroach-operator") (.Values.nodePortsEnabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/cockroach-single/cockroach-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/cockroach-single/cockroach-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "cockroach-single" }}
+{{ if and (eq .Values.database "cockroach-single") (.Values.nodePortsEnabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/infinispan/infinispan-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan") }}
+{{ if and (or (eq .Values.database "infinispan") (eq .Values.database "postgres+infinispan")) (.Values.nodePortsEnabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/templates/keycloak-jvmdebug-service.yaml
+++ b/provision/minikube/keycloak/templates/keycloak-jvmdebug-service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.nodePortsEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
   selector:
     app: keycloak
   sessionAffinity: None
+{{ end }}

--- a/provision/minikube/keycloak/templates/postgres/postgres-nodeport.yaml
+++ b/provision/minikube/keycloak/templates/postgres/postgres-nodeport.yaml
@@ -1,4 +1,4 @@
-{{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
+{{ if and (or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan")) (.Values.nodePortsEnabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -29,6 +29,7 @@ heapMaxMB: 512
 metaspaceInitMB: 96
 metaspaceMaxMB: 256
 customInfinispanConfig: false
+nodePortsEnabled: true
 portOffset: 0
 keycloakAdminPassword: admin
 disableIngressStickySession: false

--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -5,7 +5,6 @@ version: '3'
 vars:
   KC_HOSTNAME_SUFFIX: '{{default "$(kubectl get route/console -n openshift-console -o jsonpath=\u0027{.spec.host}\u0027 | cut -d . -f 2-)" .KC_HOSTNAME_SUFFIX}}'
   KC_NAMESPACE_PREFIX: '{{default "$(whoami)-" .KC_NAMESPACE_PREFIX}}'
-  KC_PORT_OFFSET: '{{default "0" .KC_PORT_OFFSET}}'
   KC_ADMIN_PASSWORD: '{{default "$(aws secretsmanager get-secret-value --region eu-central-1 --secret-id keycloak-master-password --query SecretString --output text --no-cli-pager || echo admin)" .KC_ADMIN_PASSWORD}}'
 
 output: prefixed
@@ -50,7 +49,6 @@ tasks:
       - mkdir -p .task
       - echo {{.KC_HOSTNAME_SUFFIX}} > .task/var-KC_HOSTNAME_SUFFIX
       - echo {{.KC_NAMESPACE_PREFIX}} > .task/var-KC_NAMESPACE_PREFIX
-      - echo {{.KC_PORT_OFFSET}} > .task/var-KC_PORT_OFFSET
       - echo {{.KC_ADMIN_PASSWORD}} > .task/var-KC_ADMIN_PASSWORD
     run: once
     sources:
@@ -58,7 +56,6 @@ tasks:
     status:
       - test "{{.KC_HOSTNAME_SUFFIX}}" == "$(cat .task/var-KC_HOSTNAME_SUFFIX)"
       - test "{{.KC_NAMESPACE_PREFIX}}" == "$(cat .task/var-KC_NAMESPACE_PREFIX)"
-      - test "{{.KC_PORT_OFFSET}}" == "$(cat .task/var-KC_PORT_OFFSET)"
       - test "{{.KC_ADMIN_PASSWORD}}" == '$(cat .task/var-KC_ADMIN_PASSWORD)'
 
   dataset-import:
@@ -197,9 +194,9 @@ tasks:
         --set sqlpad=false
         --set environment=openshift
         --set namespace={{.KC_NAMESPACE_PREFIX}}keycloak
-        --set portOffset={{.KC_PORT_OFFSET}}
         --set keycloakAdminPassword="{{.KC_ADMIN_PASSWORD}}"
         --set disableIngressStickySession={{ .KC_DISABLE_STICKY_SESSION }}
+        --set nodePortsEnabled=false
         ../minikube/keycloak
       - >
         bash -c '


### PR DESCRIPTION
This simplifies the installation of multiple Keycloak installations in a shared OpenShift cluster.

As those ports are AFAIK not accessible from outside of the cluster in the current setup, they are not very useful anyway.