### PR TITLE
Fix user permissions in the `benchmark` Ansible role.

### DIFF
--- a/ansible/roles/benchmark/tasks/install.yml
+++ b/ansible/roles/benchmark/tasks/install.yml
@@ -18,11 +18,11 @@
   copy:
     src: "{{ kcb_zip }}"
     dest: "/tmp/kcb.zip"
-    owner: ec2-user
+    owner: "{{ ansible_ssh_user }}"
 
 - name: Install keycloak-benchmark on the remote hosts
   unarchive:
     remote_src: true
     src: "/tmp/kcb.zip"
     dest: "{{ workspace }}"
-    owner: ec2-user
+    owner: "{{ ansible_ssh_user }}"


### PR DESCRIPTION
Replaced hard-coded `ec2-user` with dynamic Ansible value `{{ ansible_ssh_user }}`.