### PR TITLE
Do not use spot instances

### DIFF
--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -87,7 +87,7 @@ echo
 
 ./rosa_recreate_admin.sh
 
-rosa create machinepool -c "${CLUSTER_NAME}" --instance-type m5.4xlarge --max-replicas 0 --min-replicas 0 --name scaling --use-spot-instances --enable-autoscaling
+rosa create machinepool -c "${CLUSTER_NAME}" --instance-type m5.4xlarge --max-replicas 0 --min-replicas 0 --name scaling --enable-autoscaling
 
 ./rosa_efs_create.sh
 ../infinispan/install_operator.sh


### PR DESCRIPTION
When we use spot instances sometimes a worker node is removed and all pods running on that node are deleted. This can result in removing more than 1 pod, which means we are losing some sessions. This is something we cannot afford in our scalability testing, therefore removing the switch. 

I am running Keycloak with 600k user sessions at the moment with regular instances (no spot), and everything works well while with spot instances there were regular pod restarts. 