### PR TITLE
Skip waiting for Cryostat service when `KC_CRYOSTAT` is set to `false`.

### DIFF
--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -230,6 +230,7 @@ tasks:
         --set metaspaceInitMB={{ .KC_METASPACE_INIT_MB }}
         --set metaspaceMaxMB={{ .KC_METASPACE_MAX_MB }}
         --set customInfinispanConfig={{ .KC_CUSTOM_INFINISPAN_CONFIG }}
+        --set cryostat={{ .KC_CRYOSTAT }}
         keycloak
       - >
         bash -c '

--- a/provision/minikube/isup.sh
+++ b/provision/minikube/isup.sh
@@ -33,6 +33,8 @@ for SERVICE in "${!SERVICES[@]}"; do
     kubectl wait --for=condition=Ready --timeout=300s  keycloak/keycloak -n keycloak
   fi
 
+  if [[ ${SERVICE} = cryostat* ]] && ! ${KC_CRYOSTAT}; then continue; fi
+
   until kubectl get ingress -A 2>/dev/null | grep ${SERVICE} >/dev/null && curl -k -f -v https://${SERVICE}/${SERVICES[${SERVICE}]} >/dev/null 2>/dev/null
   do
     RETRIES=$(($RETRIES - 1))

--- a/provision/openshift/isup.sh
+++ b/provision/openshift/isup.sh
@@ -33,6 +33,8 @@ for SERVICE in "${!SERVICES[@]}"; do
     kubectl wait --for=condition=Ready --timeout=1200s keycloaks.k8s.keycloak.org/keycloak -n "${KC_NAMESPACE_PREFIX}keycloak"
   fi
 
+  if [[ ${SERVICE} = cryostat* ]] && ! ${KC_CRYOSTAT}; then continue; fi
+
   until kubectl get route -A 2>/dev/null | grep ${SERVICE} >/dev/null && curl -k -f -v https://${SERVICE}/${SERVICES[${SERVICE}]} >/dev/null 2>/dev/null
   do
     RETRIES=$(($RETRIES - 1))


### PR DESCRIPTION
Closes #428 .

Additionally, enabled passing of the `KC_CRYOSTAT` flag in `provisioning/minikube/Taskfile.yaml`.