### PR TITLE
Hide security-sensitive data from Ansible logs.

### DIFF
--- a/ansible/roles/aws_ec2/defaults/main.yml
+++ b/ansible/roles/aws_ec2/defaults/main.yml
@@ -7,3 +7,5 @@ ami_name: RHEL-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2
 instance_type: t3.micro
 instance_volume_size: 20
 instance_device: /dev/sda1
+
+no_log_sensitive: yes

--- a/ansible/roles/aws_ec2/tasks/create-resources.yml
+++ b/ansible/roles/aws_ec2/tasks/create-resources.yml
@@ -1,6 +1,7 @@
 - name: Get Ansible Control Host's public IP
   shell: curl -ks ifconfig.me
   register: control_host_ip
+  no_log: "{{ no_log_sensitive }}"
 
 - name: Create Security Group
   amazon.aws.ec2_group:
@@ -14,6 +15,7 @@
         to_port: 22
         cidr_ip: '{{ control_host_ip.stdout }}/32'
   register: group
+  no_log: "{{ no_log_sensitive }}"
 
 - name: Create Key
   amazon.aws.ec2_key:
@@ -21,6 +23,7 @@
     region: '{{ region }}'
     name: '{{ cluster_name }}'
   register: key
+  no_log: "{{ no_log_sensitive }}"
 
 - name: Save Private Key on Ansible Control Machine
   when: key.changed
@@ -28,6 +31,7 @@
     content: '{{ key.key.private_key }}'
     dest: '{{ cluster_name }}_{{ region }}.pem'
     mode: 0600
+  no_log: "{{ no_log_sensitive }}"
 
 - name: Look up AMI '{{ ami_name }}'
   amazon.aws.ec2_ami_info:
@@ -54,6 +58,7 @@
           volume_size: '{{ instance_volume_size }}'
           delete_on_termination: true
   register: instances
+  no_log: "{{ no_log_sensitive }}"
 
 - name: Create Inventory File
   template:

--- a/ansible/roles/aws_ec2/tasks/manage-instances.yml
+++ b/ansible/roles/aws_ec2/tasks/manage-instances.yml
@@ -6,6 +6,7 @@
     filters:
       "tag:Name": '{{ cluster_name }}*'
       instance-state-name: ['running', 'stopped', 'stopping']
+  no_log: "{{ no_log_sensitive }}"
 
 - when: operation == "start"
   block:
@@ -18,6 +19,7 @@
         "tag:Name": '{{ cluster_name }}*'
         instance-state-name: ['running']
     register: instances
+    no_log: "{{ no_log_sensitive }}"
   - name: Recreate Inventory File
     template:
       src: inventory.yml.j2


### PR DESCRIPTION
Security sensitive data like key pairs, IPs, etc. are now hidden from Ansible logs by default.

For debugging purposes these logs can be explicitly enabled by setting the Ansible variable `no_log_sensitive` to `false`.

Closes #435 