### PR TITLE
Add missing checkout step to Aurora reaper

### DIFF
--- a/.github/workflows/aurora-cluster-auto-delete-on-schedule.yml
+++ b/.github/workflows/aurora-cluster-auto-delete-on-schedule.yml
@@ -12,6 +12,9 @@ jobs:
     name: Aurora Scheduled Delete cluster(s)
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
         run: ./provision/aws/rds/aurora_cluster_reaper.sh
         env:


### PR DESCRIPTION
The reaper is failing with:

```
/home/runner/work/_temp/c0ca7b2b-7d9b-46f9-840d-25903c252923.sh: line 1: ./provision/aws/rds/aurora_cluster_reaper.sh: No such file or directory
```
This is because the code has not been checked out.