### PR TITLE
Refine Ansible playbook with max users per node and async execution

### DIFF
--- a/ansible/roles/benchmark/tasks/run.yml
+++ b/ansible/roles/benchmark/tasks/run.yml
@@ -13,7 +13,7 @@
   - debug: var=local_results_dir
 
   - set_fact: node_count="{{ groups['benchmark'] | length }}"
-  
+
   - set_fact: kcb_params_workload_per_node="{{ kcb_params }}"
   - when: '"--concurrent-users=" in kcb_params'
     block:
@@ -27,34 +27,40 @@
   - when: '"--users-per-sec=" in kcb_params'
     block:
     - set_fact: users_per_sec_per_node="{{ (kcb_params | regex_search('--users-per-sec=(\S+)', '\\1') | join('') | int) / (node_count|int) }}"
-    - debug: var=users_per_sec_per_node
+    - debug: msg="The users per second per node must not exceed 250, and the current value is {{ users_per_sec_per_node }}.{% if users_per_sec_per_node|int > 250 %} Add more nodes to create the load you asked for, or reduce the load.{% endif %}"
+      failed_when: users_per_sec_per_node|int > 250
     - set_fact: kcb_params_workload_per_node="{{ kcb_params | regex_replace('--users-per-sec=(\S+)', '--users-per-sec='+users_per_sec_per_node) }}"
-    
+
   - debug: var=kcb_params_workload_per_node
 
 
 - name: Clean up the results directory on the remote hosts
   when: kcb_clean_results
-  file: 
+  file:
     path: "{{ kcb_home }}/results"
     state: absent
 
 - name: Run keycloak-benchmark on the remote hosts
+  # Kill any currently running Java process from a previous (possibly aborted) run before starting the next.
   shell: |
+    killall java
     export CONFIG_ARGS=-Xmx{{ kcb_heap_size }}
     cd {{ kcb_home }}/bin
     ./kcb.sh {{ kcb_params_workload_per_node }} > gatling.log
   ignore_errors: yes
+  # Executing load run can be scheduled for hours. To prevent the test from failing when the SSH connection breaks, use asynchronous polling.
+  async: 86400
+  poll: 10
   register: gatling_result
 - debug: var=gatling_result
-  
+
 - name: Create local results dir
   delegate_to: localhost
   file: path="{{ local_results_dir }}" state=directory
-  
+
 - name: Fetch the Gatling run return codes
   block:
-  - template: 
+  - template:
       src: gatling.j2.rc
       dest: "{{ kcb_home }}/bin/gatling.rc"
   - name: Get Gatling return code
@@ -62,9 +68,9 @@
       src: "{{ kcb_home }}/bin/gatling.rc"
       dest: "{{ local_results_dir }}/gatling/{{ inventory_hostname }}.rc"
       flat: yes
-      
+
 - name: Fetch the latest Gatling results
-  block: 
+  block:
   - name: Find Gatling result directories
     find:
       file_type: directory

--- a/doc/benchmark/modules/ROOT/pages/run/running-benchmark-ansible.adoc
+++ b/doc/benchmark/modules/ROOT/pages/run/running-benchmark-ansible.adoc
@@ -39,11 +39,18 @@ The most important parameters to customize in `env.yml` are:
 
 `cluster_size`:: Number of instances to be created.
 As default, Gatling will create new HTTP connections for each new user.
-As the network stack of the load driver can be congested with a lot of connections in the `TIME_WAIT` state, consider using one EC2 instance per 300 users per seconds.
+As the network stack of the load driver can be congested with a lot of connections in the `TIME_WAIT` state, consider using one EC2 instance per 250 users per seconds.
 
 `instance_type`:: Size of instances to be created, see https://aws.amazon.com/ec2/instance-types/[AWS instance types].
 
 === Creating EC2 instances
+
+NOTE: Instances will be bound to the IP address of the system which creates them!
+
+When creating the instances, the public IP address of the host creating the machines is added to the EC2 security group, and only this IP address is allowed to log in to the load drivers via SSH.
+When the public IP address changes you'll need to re-run the `create` command.
+The public IP address changes, for example, when changing locations or networks, or when the internet connection at home renews the IP address every night.
+The message displayed when the IP address of the host running Ansible can't connect is "`Failed to connect to the host via ssh`".
 
 . Install the required Ansible AWS collections.
 +


### PR DESCRIPTION
This should help when the SSH connection is unstable. 
When running it this way, there are a lot of additional log messages for the polling - I hope you don't mind.

It also catches the problem automatically which was previous only documented, but not enforced.