### PR TITLE
Ciam 6580 issue 471 hiearchical groups

### DIFF
--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -979,9 +979,9 @@ public class DatasetResourceProvider implements RealmResourceProvider {
         task.debug(logger, "Created %d clients in realm %s", context.getClientCount(), context.getRealm().getName());
     }
 
-    private String getGroupName(boolean hiearchicalGroups, int hierarchyDepth, int countGroupsAtEachLevel, String prefix, int currentCount) {
+    private String getGroupName(boolean hierarchicalGroups, int countGroupsAtEachLevel, String prefix, int currentCount) {
 
-        if (!hiearchicalGroups) {
+        if (!hierarchicalGroups) {
             return prefix + currentCount;
         }
         if(currentCount == 0) {
@@ -1009,7 +1009,7 @@ public class DatasetResourceProvider implements RealmResourceProvider {
     private void createGroups(RealmContext context, int startIndex, int endIndex, boolean hierarchicalGroups, int hierarchyDepth, int countGroupsAtEachLevel, KeycloakSession session) {
         RealmModel realm = context.getRealm();
         for (int i = startIndex; i < endIndex; i++) {
-            String groupName = getGroupName(hierarchicalGroups, hierarchyDepth, countGroupsAtEachLevel, context.getConfig().getGroupPrefix(), i);
+            String groupName = getGroupName(hierarchicalGroups, countGroupsAtEachLevel, context.getConfig().getGroupPrefix(), i);
             String parentGroupName = getParentGroupName(groupName);
 
             if (parentGroupName != null) {

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -219,7 +219,8 @@ public class DatasetResourceProvider implements RealmResourceProvider {
 
         for (int i = 0; i < totalNumberOfGroups; i += config.getGroupsPerTransaction()) {
             int groupsStartIndex = i;
-            int groupEndIndex = Math.min(groupsStartIndex + config.getGroupsPerTransaction(), groupsStartIndex + config.getGroupsPerRealm());
+            int groupEndIndex =  hierarchicalGroups ? Math.min(groupsStartIndex + config.getGroupsPerTransaction(), totalNumberOfGroups)
+            : Math.min(groupsStartIndex + config.getGroupsPerTransaction(), config.getGroupsPerRealm());
 
             logger.tracef("groupsStartIndex: %d, groupsEndIndex: %d", groupsStartIndex, groupEndIndex);
 

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/DatasetResourceProvider.java
@@ -65,6 +65,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.keycloak.benchmark.dataset.config.DatasetOperation.CREATE_CLIENTS;
 import static org.keycloak.benchmark.dataset.config.DatasetOperation.CREATE_EVENTS;
@@ -989,8 +990,15 @@ public class DatasetResourceProvider implements RealmResourceProvider {
         }
         // we are using "." separated paths in the group names, this is basically a number system with countGroupsAtEachLevel being the basis
         // this allows us to find the parent group by trimming the group name even if the parent was created in previous transaction
-        int leftover = currentCount;
         StringBuilder groupName = new StringBuilder();
+        if(countGroupsAtEachLevel == 1) {
+            // numbering system does not work for base 1
+            groupName.append("0");
+            IntStream.range(0, currentCount).forEach(i -> groupName.append(GROUP_NAME_SEPARATOR).append("0"));
+            return prefix + groupName;
+        }
+
+        int leftover = currentCount;
         while (leftover > 0) {
             int digit = leftover % countGroupsAtEachLevel;
             groupName.insert(0, digit + GROUP_NAME_SEPARATOR);

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
@@ -119,6 +119,16 @@ public class DatasetConfig {
     @QueryParamIntFill(paramName = "groups-per-transaction", defaultValue = 100, operations = { CREATE_REALMS })
     private Integer groupsPerTransaction;
 
+    @QueryParamFill(paramName = "groups-with-hierarchy", defaultValue = "false", operations = { CREATE_REALMS })
+    private String groupsWithHierarchy;
+
+    @QueryParamIntFill(paramName = "groups-hierarchy-depth", defaultValue = 3, operations = { CREATE_REALMS })
+    private Integer groupsHierarchyDepth;
+
+    @QueryParamIntFill(paramName = "groups-count-each-level", defaultValue = 10, operations = { CREATE_REALMS })
+    private Integer countGroupsAtEachLevel;
+
+
     // Prefix for newly created users
     @QueryParamFill(paramName = "user-prefix", defaultValue = "user-", operations = { CREATE_REALMS, CREATE_USERS, CREATE_OFFLINE_SESSIONS, LAST_USER, CREATE_AUTHZ_CLIENT })
     private String userPrefix;
@@ -269,6 +279,13 @@ public class DatasetConfig {
     public Integer getGroupsPerUser() {
         return groupsPerUser;
     }
+
+    public String getGroupsWithHierarchy() {return groupsWithHierarchy;}
+
+    public Integer getGroupsHierarchyDepth() {return groupsHierarchyDepth;}
+
+    public Integer getCountGroupsAtEachLevel() {return countGroupsAtEachLevel;}
+
 
     public Integer getRealmRolesPerUser() {
         return realmRolesPerUser;

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
@@ -280,12 +280,17 @@ public class DatasetConfig {
         return groupsPerUser;
     }
 
-    public String getGroupsWithHierarchy() {return groupsWithHierarchy;}
+    public String getGroupsWithHierarchy() {
+        return groupsWithHierarchy;
+    }
 
-    public Integer getGroupsHierarchyDepth() {return groupsHierarchyDepth;}
+    public Integer getGroupsHierarchyDepth() {
+        return groupsHierarchyDepth;
+    }
 
-    public Integer getCountGroupsAtEachLevel() {return countGroupsAtEachLevel;}
-
+    public Integer getCountGroupsAtEachLevel() {
+        return countGroupsAtEachLevel;
+    }
 
     public Integer getRealmRolesPerUser() {
         return realmRolesPerUser;

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/config/DatasetConfig.java
@@ -116,15 +116,19 @@ public class DatasetConfig {
     @QueryParamIntFill(paramName = "groups-per-realm", defaultValue = 20, operations = { CREATE_REALMS })
     private Integer groupsPerRealm;
 
+    // Number of groups to be created in one transaction
     @QueryParamIntFill(paramName = "groups-per-transaction", defaultValue = 100, operations = { CREATE_REALMS })
     private Integer groupsPerTransaction;
 
+    // When this parameter is false only top level groups are created, groups and subgroups are created
     @QueryParamFill(paramName = "groups-with-hierarchy", defaultValue = "false", operations = { CREATE_REALMS })
     private String groupsWithHierarchy;
 
+   // Depth of the group hierarchy tree. Active if groups-with-hierarchy = true
     @QueryParamIntFill(paramName = "groups-hierarchy-depth", defaultValue = 3, operations = { CREATE_REALMS })
     private Integer groupsHierarchyDepth;
 
+    // Number of at each level of hierarchy. Each group will have this many subgroups. Active if groups-with-hierarchy = true
     @QueryParamIntFill(paramName = "groups-count-each-level", defaultValue = 10, operations = { CREATE_REALMS })
     private Integer countGroupsAtEachLevel;
 

--- a/doc/dataset/modules/ROOT/pages/using-provider.adoc
+++ b/doc/dataset/modules/ROOT/pages/using-provider.adoc
@@ -99,6 +99,23 @@ Each user will have password like «Username»-password . For example `user-156`
 .../realms/master/dataset/create-users?count=1000&realm-name=realm-5
 ----
 
+=== Create many groups
+
+Groups are created as part of the realm creation. Number of groups and the structure of the created groups can be managed by using the following parameters:
+
+* groups-per-realm: Total number of groups per realm. Default value is 20.
+* groups-per-transaction: Number of groups to be created in one transaction. Default value is 100.
+* groups-with-hierarchy: "true" or "false", the default value is "false". With the default value only top-level groups are created. With groups-with-hierarchy = 'true' a tree structure of groups is created; the depth of the tree is defined by the parameter 'groups-hierarchy-depth' and 'groups-count-each-level' defines how many subgroups each created group will have.
+* groups-hierarchy-depth: The depth of the groups tree structure. Default value is 3. With the default value top level groups will have 'groups-count-each-level' subgroups and each subgroup will have 'groups-count-each-level' themselves. This parameter is active only when 'groups-with-hierarchy' is true.
+* groups-count-each-level: Number of subgroups each created group will have. This parameter is active only when 'groups-with-hierarchy' is true.
+
+With the default values only top-level groups are created. With groups-with-hierarchy=true, groups-per-realm parameter is ignored and the group tree structure is created by as defined by the other parameters. groups-count-each-level ^ groups-hierarchy-depth will be the total number of groups created. The hierarchical groups implementation honors groups-per-transaction.
+The adopted subgroup naming convention  uses "." in the group names which allows finding the parent group even if it was created in a previous transaction.
+
+----
+.../realms/master/dataset/create-realms?count=1&groups-with-hierarchy=true&groups-hierarchy-depth=3&groups-count-each-level=50
+----
+
 === Create many events
 
 This is request to create 10M new events in the available realms with prefix `realm-`.

--- a/doc/dataset/modules/ROOT/pages/using-provider.adoc
+++ b/doc/dataset/modules/ROOT/pages/using-provider.adoc
@@ -18,7 +18,7 @@ For the Wildfly distribution, the URL starts with `/auth/realms/master`.
 
 This script contains a subset of the operations described in the next sections around realms, users and clients.
 
-The script assumes that the dataset provider is installed as described in xref:kubernetes-guide::installation.adoc[] setup and that it is available at +
+The script assumes that the dataset provider is installed as described in xref:kubernetes-guide::installation-minikube.adoc[] setup and that it is available at +
 `++https://keycloak-keycloak.$(minikube ip).nip.io/realms/master/dataset/++`.
 
 Run the following command to receive a help description:
@@ -101,17 +101,32 @@ Each user will have password like «Username»-password . For example `user-156`
 
 === Create many groups
 
-Groups are created as part of the realm creation. Number of groups and the structure of the created groups can be managed by using the following parameters:
+Groups are created as part of the realm creation.
+The number of groups and the structure of the created groups can be managed by using the following parameters:
 
-* groups-per-realm: Total number of groups per realm. Default value is 20.
-* groups-per-transaction: Number of groups to be created in one transaction. Default value is 100.
-* groups-with-hierarchy: "true" or "false", the default value is "false". With the default value only top-level groups are created. With groups-with-hierarchy = 'true' a tree structure of groups is created; the depth of the tree is defined by the parameter 'groups-hierarchy-depth' and 'groups-count-each-level' defines how many subgroups each created group will have.
-* groups-hierarchy-depth: The depth of the groups tree structure. Default value is 3. With the default value top level groups will have 'groups-count-each-level' subgroups and each subgroup will have 'groups-count-each-level' themselves. This parameter is active only when 'groups-with-hierarchy' is true.
-* groups-count-each-level: Number of subgroups each created group will have. This parameter is active only when 'groups-with-hierarchy' is true.
+`groups-per-realm`:: Total number of groups per realm.
+The default value is `20`.
 
-With the default values only top-level groups are created. With groups-with-hierarchy=true, groups-per-realm parameter is ignored and the group tree structure is created by as defined by the other parameters. groups-count-each-level ^ groups-hierarchy-depth will be the total number of groups created. The hierarchical groups implementation honors groups-per-transaction.
-The adopted subgroup naming convention  uses "." in the group names which allows finding the parent group even if it was created in a previous transaction.
+`groups-per-transaction`:: Number of groups to be created in one transaction.
+The default value is `100`.
 
+`groups-with-hierarchy`:: `true` or `false`, the default value is `false`.
+With the default value, only top-level groups are created.
+With groups-with-hierarchy set to `true` a tree structure of groups is created; the depth of the tree is defined by the parameter `groups-hierarchy-depth` and `groups-count-each-level` defines how many subgroups each created group will have.
+
+`groups-hierarchy-depth`:: The depth of the groups tree structure.
+The default value is 3. With the default value, top level groups will have `groups-count-each-level` subgroups and each subgroup will have `groups-count-each-level` themselves.
+This parameter is active only when `groups-with-hierarchy` is `true`.
+
+`groups-count-each-level`:: Number of subgroups each created group will have.
+This parameter is active only when `groups-with-hierarchy` is `true`.
+
+With the default values, only top-level groups are created.
+With `groups-with-hierarchy` set to `true`, the `groups-per-realm` parameter is ignored and the group tree structure is created as defined by the other parameters. `groups-count-each-level`^`groups-hierarchy-depth`^  will be the total number of groups created.
+The hierarchical groups implementation honors groups-per-transaction.
+The adopted subgroup naming convention uses a dot (`.`) in the group names which allows finding the parent group even if it was created in a previous transaction.
+
+.Example parameters
 ----
 .../realms/master/dataset/create-realms?count=1&groups-with-hierarchy=true&groups-hierarchy-depth=3&groups-count-each-level=50
 ----


### PR DESCRIPTION
This PR creates hierarchical groups using the configuration parameters: groups-count-each-level, groups-hierarchy-depth, groups-with-hierarchy.  Boolean parameter groups-with-hierarchy is "false" by default. With the default values it works as before. 

With groups-with-hierarchy=true, it ignores groups-per-realm parameter and creates the group tree structure as defined by the other parameters. This will be groups-count-each-level ^ groups-hierarchy-depth. 

The implementation honors groups-per-transaction.

We adopted a subgroup naming convention that uses "." in the group names which allows finding the parent group even if it was created in a previous transaction.

Closes #471