### PR TITLE
Aurora multi region

### DIFF
--- a/.github/workflows/rosa-cluster-create.yml
+++ b/.github/workflows/rosa-cluster-create.yml
@@ -21,6 +21,11 @@ on:
         required: true
         default: '2'
         type: string
+      machineCidr:
+        description: 'Machine CIDR of the ROSA cluster'
+        required: true
+        default: '10.0.0.0/16'
+        type: string
 
 concurrency: cluster_${{ github.event.inputs.clusterName || format('gh-{0}', github.repository_owner) }}
 
@@ -54,6 +59,7 @@ jobs:
           COMPUTE_MACHINE_TYPE: ${{ inputs.computeMachineType }}
           MULTI_AZ: ${{ inputs.multiAz }}
           REPLICAS: ${{ inputs.replicas }}
+          MACHINE_CIDR: ${{ inputs.machineCidr }}
 
       - name: Archive ROSA logs
         uses: actions/upload-artifact@v3

--- a/doc/kubernetes/modules/ROOT/nav.adoc
+++ b/doc/kubernetes/modules/ROOT/nav.adoc
@@ -15,6 +15,7 @@
 * xref:customizing-deployment.adoc[]
 * xref:storage-configurations.adoc[]
 ** xref:storage/postgres.adoc[]
+** xref:storage/aurora-postgres.adoc[]
 ** xref:storage/cockroach-single.adoc[]
 ** xref:storage/cockroach-operator.adoc[]
 ** xref:storage/infinispan.adoc[]

--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-rosa.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-rosa.adoc
@@ -39,6 +39,7 @@ REGION=eu-central-1
 COMPUTE_MACHINE_TYPE=m5.xlarge
 MULTI_AZ=false
 REPLICAS=3
+
 ----
 
 === Mandatory parameters
@@ -66,6 +67,8 @@ If not set, the value of the `$(whoami)` command will be used.
 If not set, it is obtained from AWS Secrets Manager secret equal to `KEYCLOAK_MASTER_PASSWORD_SECRET_NAME` parameter.
 `KEYCLOAK_MASTER_PASSWORD_SECRET_NAME`:: Name of the AWS Secrets Manager secret containing the password for the `cluster-admin` user.
 Defaults to `keycloak-master-password`.
+`MACHINE_CIDR`:: Machine CIDR field, you must specify the IP address range for machines or cluster nodes.
+This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Defaults to `10.0.0.0/16`.
 
 == Finding URLs
 

--- a/doc/kubernetes/modules/ROOT/pages/storage/aurora-postgres.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/storage/aurora-postgres.adoc
@@ -39,6 +39,8 @@ CLUSTER_NAME= # The name of the ROSA cluster to establish the peering connectin 
 AWS_REGION= # The AWS region hosting the ROSA cluster
 ----
 
+NOTE: If connecting multiple ROSA clusters from different AWS regions to the Aurora DB, it's necessary for each cluster
+to have non-overlapping machine-cidr configured.
 
 == Enabling Aurora PostgreSQL storage
 

--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -33,6 +33,8 @@ else
 
   echo "Installing ROSA cluster ${CLUSTER_NAME}"
 
+  MACHINE_CIDR=${MACHINE_CIDR:-"10.0.0.0/16"}
+
   ROSA_CMD="rosa create cluster \
   --sts \
   --cluster-name ${CLUSTER_NAME} \
@@ -45,7 +47,7 @@ else
   --region ${REGION} ${MULTI_AZ_PARAM} \
   --replicas ${REPLICAS} \
   --compute-machine-type ${COMPUTE_MACHINE_TYPE} \
-  --machine-cidr 10.0.0.0/16 \
+  --machine-cidr ${MACHINE_CIDR} \
   --service-cidr 172.30.0.0/16 \
   --pod-cidr 10.128.0.0/14 \
   --host-prefix 23"


### PR DESCRIPTION
It's necessary for each ROSA cluster to use a non-overlapping
machine-cidr range when deploying across multiple AWS regions. If the
cidr range overlaps, then Aurora DB responses will not be correctly
routed to cluster than initiated a request.

Resolves https://github.com/keycloak/keycloak-benchmark/issues/467

@ahus1 @mhajas Utilising VPC peering connections to limit DB accessibility is the way to go when deploying production systems, but I'm starting to think it might be getting too restrictive for benchmarking with many clusters. If this continues be a pain point, I think we should consider documenting the steps required for said setup and then simply revert to using Aurora endpoints exposed over the internet.