### PR TITLE
Hardcode JGroups cluster name to match Keycloak embedded settings

### DIFF
--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -38,7 +38,7 @@ spec:
     enabled: false
   replicas: {{ .Values.replicas }}
   container:
-    extraJvmOpts: '-Dorg.infinispan.openssl=false {{.Values.jvmOptions}}'
+    extraJvmOpts: '-Dorg.infinispan.openssl=false -Dinfinispan.cluster.name=ISPN {{.Values.jvmOptions}}'
     {{- if .Values.cpu }}
     cpu: {{ .Values.cpu }}
     {{- end}}


### PR DESCRIPTION
This is a quick and easy way for us to make the external metric names align with the embedded infinispan names. A better solution would be to explicitly set the JGroups cluster name in the Keycloak EmbeddedCacheManager to a meaningful name associated with a specific Keycloak instance. I'll discuss this with the team and contribute a Keycloak PR as required.

Relates to: https://github.com/keycloak/keycloak-benchmark/issues/464