### PR TITLE
Automation of Rosa Scaling Benchmark (#444): Part 2

### DIFF
--- a/.github/actions/keycloak-create-dataset/action.yml
+++ b/.github/actions/keycloak-create-dataset/action.yml
@@ -43,7 +43,7 @@ runs:
       working-directory: dataset
 
     - id: create_clients_for_realm
-      if: ${{ inputs.createClientForSpecificRealm }}
+      if: ${{ inputs.createClientForSpecificRealm == 'true' }}
       shell: bash
       run: |
         ./dataset-import.sh -a create-clients -c ${{ inputs.clientsPerRealm }} -n ${{ inputs.realmNameForClients }} -l ${{ env.KEYCLOAK_URL }}/realms/master/dataset

--- a/.github/actions/prometheus-metrics-calc/action.yml
+++ b/.github/actions/prometheus-metrics-calc/action.yml
@@ -89,9 +89,9 @@ runs:
         description="${{ inputs.calculatedMetricName }} per Pod in ${{ inputs.replicas }} Pod cluster"
         if [ -f ${{ inputs.output }} ]; then
           cat ${{ inputs.output }} | jq --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
-          --arg val ${CALCULATED_METRIC_VALUE} '. + {($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' \
+          --arg val ${CALCULATED_METRIC_VALUE} '. + {($testName): {($key):($val|tonumber)}}' \
           | tee ${{ inputs.output }}
         else
           jq -n --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
-          --arg val ${CALCULATED_METRIC_VALUE} '{($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' > ${{ inputs.output }}
+          --arg val ${CALCULATED_METRIC_VALUE} '{($testName): {($key):($val|tonumber)}}' > ${{ inputs.output }}
         fi

--- a/.github/actions/prometheus-metrics-calc/action.yml
+++ b/.github/actions/prometheus-metrics-calc/action.yml
@@ -11,9 +11,6 @@ inputs:
   calculatedMetricName:
     description: 'The name of the metric that is calculated for including in JSON file.'
     default: '1vCPU'
-  criteriaName:
-    description: 'The name of the criteria for which the metric is calculated.'
-    default: 'users per sec'
   criteriaValue:
     description: 'The value for the criteria used during benchmark run.'
     required: true
@@ -56,7 +53,7 @@ runs:
         metric_per_pod=$(awk "BEGIN {print $metric_count_in_interval/$POD_NUM; exit}")
         #Calculating the final number, i.e. how many of specified criteria (e.g. user logins/sec, client credential grants, etc)
         #can be handled with requested metric per pod. The result is number rounded down.
-        result=$(awk "BEGIN {print int($CRITERIA_VALUE/$metric_per_pod); exit}"
+        result=$(awk "BEGIN {print int($CRITERIA_VALUE/$metric_per_pod); exit}")
         echo "CALCULATED_METRIC_VALUE=$result" >> $GITHUB_ENV
 
     - id: calculate-memory-metric
@@ -78,7 +75,7 @@ runs:
         metric_per_pod=$(awk "BEGIN {print $difference/$POD_NUM; exit}")
         #Calculating the final number, i.e. based on current environment setup how many of specified criteria (e.g. user active session, etc)
         #can be handled with 500Mb per pod based on the number calculated above. The result is number rounded down.
-        result=$(awk "BEGIN {print int($CRITERIA_VALUE*500/$metric_per_pod); exit}"
+        result=$(awk "BEGIN {print int($CRITERIA_VALUE*500/$metric_per_pod); exit}")
         echo "CALCULATED_METRIC_VALUE=$result" >> $GITHUB_ENV
 
     - id: metric-store-in-result-file
@@ -89,12 +86,12 @@ runs:
       # language=bash
       run: |
         #Preparing and storing all information in JSON using jq library
-        description="${{ inputs.calculatedMetricName }} per pod in ${{ inputs.replicas }} node cluster handles"
+        description="${{ inputs.calculatedMetricName }} per Pod in ${{ inputs.replicas }} Pod cluster"
         if [ -f ${{ inputs.output }} ]; then
           cat ${{ inputs.output }} | jq --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
-          --arg val "${CALCULATED_METRIC_VALUE} ${{ inputs.criteriaName }}" '. + {($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' \
+          --arg val ${CALCULATED_METRIC_VALUE} '. + {($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' \
           | tee ${{ inputs.output }}
         else
           jq -n --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
-          --arg val "${CALCULATED_METRIC_VALUE} ${{ inputs.criteriaName }}" '{($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' > ${{ inputs.output }}
+          --arg val ${CALCULATED_METRIC_VALUE} '{($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' > ${{ inputs.output }}
         fi

--- a/.github/actions/prometheus-metrics-calc/action.yml
+++ b/.github/actions/prometheus-metrics-calc/action.yml
@@ -1,0 +1,97 @@
+name: Execute metrics calculation
+description: Execute metrics calculation
+
+inputs:
+  input:
+    description: 'The file name containing result numbers.'
+    required: true
+  performedTestName:
+    description: 'The name of the performed test to include in JSON file.'
+    required: true
+  calculatedMetricName:
+    description: 'The name of the metric that is calculated for including in JSON file.'
+    default: '1vCPU'
+  criteriaName:
+    description: 'The name of the criteria for which the metric is calculated.'
+    default: 'users per sec'
+  criteriaValue:
+    description: 'The value for the criteria used during benchmark run.'
+    required: true
+  isvCPU:
+    description: 'Defines if vCPU metric is calculated.'
+    default: 'true'
+  isMemory:
+    description: 'Defines if memory metric is calculated.'
+    default: 'false'
+  replicas:
+    description: 'Number of pods on which the metric is calculated.'
+    default: '3'
+  measurementInterval:
+    description: 'A specific time period over which we want to calculate the required metrics.'
+  output:
+    description: 'The name of the output to store data in JSON format'
+    default: 'results.json'
+
+runs:
+  using: composite
+  steps:
+    - id: calculate-vcpu-metrics
+      name: Calculate the vCPU metric and store environment variable.
+      if: ${{ inputs.isvCPU == 'true' }}
+      env:
+        POD_NUM: ${{ inputs.replicas }}             #redefining the input parameters as environment variables due to math operations below
+        CRITERIA_VALUE: ${{ inputs.criteriaValue }}
+        TIME_INTERVAL: ${{ inputs.measurementInterval }}
+      shell: bash
+      run: |
+        readarray -t lines < ${{ inputs.input }}
+        num1=${lines[0]}
+        num2=${lines[1]}
+        #calculating the difference of cumulative metric (changed during the benchmark execution)
+        difference=$(awk "BEGIN {print ($num2-$num1); exit}")
+        #the script calculates vCPU need to calculate the vcpu number from CPU seconds metrics for the interval during which the test was running
+        metric_count_in_interval=$(awk "BEGIN {print $difference/$TIME_INTERVAL; exit}")
+        #calculating the average metric per pod
+        metric_per_pod=$(awk "BEGIN {print $metric_count_in_interval/$POD_NUM; exit}")
+        #Calculating the final number, i.e. how many of specified criteria (e.g. user logins/sec, client credential grants, etc)
+        #can be handled with requested metric per pod. The result is number rounded down.
+        result=$(awk "BEGIN {print $CRITERIA_VALUE/$metric_per_pod; exit}" | sed 's/\..*//')
+        echo "CALCULATED_METRIC_VALUE=$result" >> $GITHUB_ENV
+
+    - id: calculate-memory-metric
+      name: Calculate the memory metric and store in environment variable.
+      if: ${{ inputs.isMemory == 'true' }}
+      env:
+        POD_NUM: ${{ inputs.replicas }}             #redefining the input parameters as environment variables due to math operations below
+        CRITERIA_VALUE: ${{ inputs.criteriaValue }}
+        TIME_INTERVAL: ${{ inputs.measurementInterval }}
+      shell: bash
+      run: |
+        readarray -t lines < ${{ inputs.input }}
+        num1=${lines[0]}
+        num2=${lines[1]}
+        #calculating the difference of cumulative metric (changed during the benchmark execution)
+        difference=$(awk "BEGIN {print ($num2-$num1); exit}")
+        #calculating the average metric per pod
+        metric_per_pod=$(awk "BEGIN {print $difference/$POD_NUM; exit}")
+        #Calculating the final number, i.e. based on current environment setup how many of specified criteria (e.g. user active session, etc)
+        #can be handled with 500Mb per pod based on the number calculated above. The result is number rounded down.
+        result=$(awk "BEGIN {print $CRITERIA_VALUE*500/$metric_per_pod; exit}" | sed 's/\..*//')
+        echo "CALCULATED_METRIC_VALUE=$result" >> $GITHUB_ENV
+
+    - id: metric-store-in-result-file
+      name: Stores got information in JSON file.
+      env:
+        CALCULATED_METRIC_VALUE: ${{ env.CALCULATED_METRIC_VALUE }}
+      shell: bash
+      run: |
+        #Preparing and storing all information in JSON using jq library
+        description="${{ inputs.calculatedMetricName }} per pod in ${{ inputs.replicas }} node cluster handles:"
+        if [ -f ${{ inputs.output }} ]; then
+          cat ${{ inputs.output }} | jq --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
+          --arg val "${CALCULATED_METRIC_VALUE} ${{ inputs.criteriaName }}" '. + {($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' \
+          | tee ${{ inputs.output }}
+        else
+          jq -n --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
+          --arg val "${CALCULATED_METRIC_VALUE} ${{ inputs.criteriaName }}" '{($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' > ${{ inputs.output }}
+        fi

--- a/.github/actions/prometheus-metrics-calc/action.yml
+++ b/.github/actions/prometheus-metrics-calc/action.yml
@@ -43,6 +43,7 @@ runs:
         CRITERIA_VALUE: ${{ inputs.criteriaValue }}
         TIME_INTERVAL: ${{ inputs.measurementInterval }}
       shell: bash
+      # language=bash
       run: |
         readarray -t lines < ${{ inputs.input }}
         num1=${lines[0]}
@@ -55,7 +56,7 @@ runs:
         metric_per_pod=$(awk "BEGIN {print $metric_count_in_interval/$POD_NUM; exit}")
         #Calculating the final number, i.e. how many of specified criteria (e.g. user logins/sec, client credential grants, etc)
         #can be handled with requested metric per pod. The result is number rounded down.
-        result=$(awk "BEGIN {print $CRITERIA_VALUE/$metric_per_pod; exit}" | sed 's/\..*//')
+        result=$(awk "BEGIN {print int($CRITERIA_VALUE/$metric_per_pod); exit}"
         echo "CALCULATED_METRIC_VALUE=$result" >> $GITHUB_ENV
 
     - id: calculate-memory-metric
@@ -66,6 +67,7 @@ runs:
         CRITERIA_VALUE: ${{ inputs.criteriaValue }}
         TIME_INTERVAL: ${{ inputs.measurementInterval }}
       shell: bash
+      # language=bash
       run: |
         readarray -t lines < ${{ inputs.input }}
         num1=${lines[0]}
@@ -76,7 +78,7 @@ runs:
         metric_per_pod=$(awk "BEGIN {print $difference/$POD_NUM; exit}")
         #Calculating the final number, i.e. based on current environment setup how many of specified criteria (e.g. user active session, etc)
         #can be handled with 500Mb per pod based on the number calculated above. The result is number rounded down.
-        result=$(awk "BEGIN {print $CRITERIA_VALUE*500/$metric_per_pod; exit}" | sed 's/\..*//')
+        result=$(awk "BEGIN {print int($CRITERIA_VALUE*500/$metric_per_pod); exit}"
         echo "CALCULATED_METRIC_VALUE=$result" >> $GITHUB_ENV
 
     - id: metric-store-in-result-file
@@ -84,9 +86,10 @@ runs:
       env:
         CALCULATED_METRIC_VALUE: ${{ env.CALCULATED_METRIC_VALUE }}
       shell: bash
+      # language=bash
       run: |
         #Preparing and storing all information in JSON using jq library
-        description="${{ inputs.calculatedMetricName }} per pod in ${{ inputs.replicas }} node cluster handles:"
+        description="${{ inputs.calculatedMetricName }} per pod in ${{ inputs.replicas }} node cluster handles"
         if [ -f ${{ inputs.output }} ]; then
           cat ${{ inputs.output }} | jq --arg testName "${{ inputs.performedTestName }}" --arg key "${description}" \
           --arg val "${CALCULATED_METRIC_VALUE} ${{ inputs.criteriaName }}" '. + {($testName): {($ARGS.named["key"]):($ARGS.named["val"])}}' \

--- a/.github/actions/prometheus-run-queries/action.yml
+++ b/.github/actions/prometheus-run-queries/action.yml
@@ -25,6 +25,7 @@ runs:
         host=$(oc -n openshift-monitoring get route thanos-querier -ojsonpath='{.spec.host}')
         token=$(oc whoami -t)
         echo "THANOS_HOST=$host" >> $GITHUB_ENV
+        echo "::add-mask::$token"
         echo "OC_TOKEN=$token" >> $GITHUB_ENV
 
     - id: cpu-sec-util-query

--- a/.github/actions/prometheus-run-queries/action.yml
+++ b/.github/actions/prometheus-run-queries/action.yml
@@ -44,11 +44,11 @@ runs:
       name: Memory Usage Total
       if: ${{ inputs.runMemoryUsageTotal == 'true' }}
       shell: bash
-      # Converting Bytes to MB before storing to file.
+      # language=bash
       run: >
         curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode
         'query=sum(container_memory_working_set_bytes{job="kubelet", namespace="${{ inputs.project }}",container="keycloak"})'
-        | jq '.data.result[0].value[1]' -r | awk '{print $0/1000/1000}' >> ${{ inputs.output }}
+        | jq '.data.result[0].value[1]' -r | awk '{print $0/1000/1000}' >> ${{ inputs.output }}       # Converting Bytes to MB before storing to file.
       env:
         THANOS_HOST: ${{ env.THANOS_HOST }}
         OC_TOKEN: ${{ env.OC_TOKEN }}

--- a/.github/actions/prometheus-run-queries/action.yml
+++ b/.github/actions/prometheus-run-queries/action.yml
@@ -1,0 +1,53 @@
+name: Run Prometheus Queries
+description: Run Prometheus Queries
+
+inputs:
+  project:
+    description: 'The name of keycloak namespace'
+    default: 'runner-keycloak'
+  runCpuSecsUtil:
+    description: 'Identifies if "CPU Secs Util." query should be run.'
+    default: 'false'
+  runMemoryUsageTotal:
+    description: 'Identifies if "Memory Usage Total" query should be run.'
+    default: 'false'
+  output:
+    description: 'The name of the output to store data in'
+    default: 'out'
+
+runs:
+  using: composite
+  steps:
+    - id: retrieve-token
+      name: Retrieving token and Thanos host and set as Env Variables
+      shell: bash
+      run: |
+        host=$(oc -n openshift-monitoring get route thanos-querier -ojsonpath='{.spec.host}')
+        token=$(oc whoami -t)
+        echo "THANOS_HOST=$host" >> $GITHUB_ENV
+        echo "OC_TOKEN=$token" >> $GITHUB_ENV
+
+    - id: cpu-sec-util-query
+      name: CPU Sec Util
+      if: ${{ inputs.runCpuSecsUtil == 'true' }}
+      shell: bash
+      run: |
+        curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode \
+        'query=sum(container_cpu_usage_seconds_total{job="kubelet", namespace="${{   inputs.project }}",container="keycloak"})' \
+        | jq '.data.result[0].value[1]' -r >> ${{ inputs.output }}
+      env:
+        THANOS_HOST: ${{ env.THANOS_HOST }}
+        OC_TOKEN: ${{ env.OC_TOKEN }}
+
+    - id: memory-usage-total-query
+      name: Memory Usage Total
+      if: ${{ inputs.runMemoryUsageTotal == 'true' }}
+      shell: bash
+      run: |
+        #Converting Bytes to MB before storing to file.
+        curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode \
+        'query=sum(container_memory_working_set_bytes{job="kubelet", namespace="${{ inputs.project }}",container="keycloak"})' \
+        | jq '.data.result[0].value[1]' -r | awk '{print $0/1000/1000}' >> ${{ inputs.output }}
+      env:
+        THANOS_HOST: ${{ env.THANOS_HOST }}
+        OC_TOKEN: ${{ env.OC_TOKEN }}

--- a/.github/actions/prometheus-run-queries/action.yml
+++ b/.github/actions/prometheus-run-queries/action.yml
@@ -31,9 +31,10 @@ runs:
       name: CPU Sec Util
       if: ${{ inputs.runCpuSecsUtil == 'true' }}
       shell: bash
-      run: |
-        curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode \
-        'query=sum(container_cpu_usage_seconds_total{job="kubelet", namespace="${{   inputs.project }}",container="keycloak"})' \
+      # language=bash
+      run: >
+        curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode
+        'query=sum(container_cpu_usage_seconds_total{job="kubelet", namespace="${{   inputs.project }}",container="keycloak"})'
         | jq '.data.result[0].value[1]' -r >> ${{ inputs.output }}
       env:
         THANOS_HOST: ${{ env.THANOS_HOST }}
@@ -43,10 +44,10 @@ runs:
       name: Memory Usage Total
       if: ${{ inputs.runMemoryUsageTotal == 'true' }}
       shell: bash
-      run: |
-        #Converting Bytes to MB before storing to file.
-        curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode \
-        'query=sum(container_memory_working_set_bytes{job="kubelet", namespace="${{ inputs.project }}",container="keycloak"})' \
+      # Converting Bytes to MB before storing to file.
+      run: >
+        curl -s -H "Authorization: Bearer $OC_TOKEN" -k "https://$THANOS_HOST/api/v1/query" --data-urlencode
+        'query=sum(container_memory_working_set_bytes{job="kubelet", namespace="${{ inputs.project }}",container="keycloak"})'
         | jq '.data.result[0].value[1]' -r | awk '{print $0/1000/1000}' >> ${{ inputs.output }}
       env:
         THANOS_HOST: ${{ env.THANOS_HOST }}

--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -150,17 +150,17 @@ jobs:
 
       - name: Testing memory for creating sessions
         id: kcb-authorization-code-1
-        run: |
-          ./benchmark.sh ${{ inputs.region }} \
-          --scenario=keycloak.scenario.authentication.AuthorizationCode \
-          --server-url=${{ env.KEYCLOAK_URL }} \
-          --realm-name=realm-0 \
-          --users-per-sec=${{ inputs.numberOfUsersPerSecond }} \
-          --ramp-up=20 \
-          --logout-percentage=0 \
-          --measurement=${{ inputs.measurement }} \
-          --users-per-realm=${{ inputs.numberOfEntitiesInRealm }} \
-          --log-http-on-failure \
+        run: >
+          ./benchmark.sh ${{ inputs.region }}
+          --scenario=keycloak.scenario.authentication.AuthorizationCode
+          --server-url=${{ env.KEYCLOAK_URL }}
+          --realm-name=realm-0
+          --users-per-sec=${{ inputs.numberOfUsersPerSecond }}
+          --ramp-up=20
+          --logout-percentage=0
+          --measurement=${{ inputs.measurement }}
+          --users-per-realm=${{ inputs.numberOfEntitiesInRealm }}
+          --log-http-on-failure
           --sla-error-percentage=0.001
         continue-on-error: true
         working-directory: ansible
@@ -192,17 +192,17 @@ jobs:
 
       - name: Testing CPU usage for user logins
         id: kcb-authorization-code-2
-        run: |
-          ./benchmark.sh ${{ inputs.region }}  \
-          --scenario=keycloak.scenario.authentication.AuthorizationCode \
-          --server-url=${{ env.KEYCLOAK_URL }} \
-          --realm-name=realm-0 \
-          --users-per-sec=${{ inputs.numberOfUsersPerSecond }} \
-          --ramp-up=20 \
-          --logout-percentage=100 \
-          --measurement=${{ inputs.measurement }} \
-          --users-per-realm=${{ inputs.numberOfEntitiesInRealm }} \
-          --log-http-on-failure \
+        run: >
+          ./benchmark.sh ${{ inputs.region }}
+          --scenario=keycloak.scenario.authentication.AuthorizationCode
+          --server-url=${{ env.KEYCLOAK_URL }}
+          --realm-name=realm-0
+          --users-per-sec=${{ inputs.numberOfUsersPerSecond }}
+          --ramp-up=20
+          --logout-percentage=100
+          --measurement=${{ inputs.measurement }}
+          --users-per-realm=${{ inputs.numberOfEntitiesInRealm }}
+          --log-http-on-failure
           --sla-error-percentage=0.001
         continue-on-error: true
         working-directory: ansible
@@ -234,16 +234,16 @@ jobs:
 
       - name: Testing CPU usage for client credential grants
         id: kcb-client-secret
-        run: |
-          ./benchmark.sh ${{ inputs.region }} \
-          --scenario=keycloak.scenario.authentication.ClientSecret \
-          --server-url=${{ env.KEYCLOAK_URL }} \
-          --realm-name=realm-0 \
-          --users-per-sec=${{ inputs.numberOfClientsPerSecond }} \
-          --ramp-up=20 \
-          --measurement=${{ inputs.measurement }} \
-          --users-per-realm=${{ inputs.numberOfEntitiesInRealm }} \
-          --log-http-on-failure \
+        run: >
+          ./benchmark.sh ${{ inputs.region }}
+          --scenario=keycloak.scenario.authentication.ClientSecret
+          --server-url=${{ env.KEYCLOAK_URL }}
+          --realm-name=realm-0
+          --users-per-sec=${{ inputs.numberOfClientsPerSecond }}
+          --ramp-up=20
+          --measurement=${{ inputs.measurement }}
+          --users-per-realm=${{ inputs.numberOfEntitiesInRealm }}
+          --log-http-on-failure
           --sla-error-percentage=0.001
         continue-on-error: true
         working-directory: ansible

--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -172,14 +172,20 @@ jobs:
           runMemoryUsageTotal: true
           output: memory_create_sessions
 
+      - name: Calculate number of active sessions
+        id: active_sessions_count
+        env:
+          USERS_PER_SEC: ${{ inputs.numberOfUsersPerSecond }}
+          TIME_IN_SEC: ${{ inputs.measurement }}
+        run: echo "active_sessions=$(awk "BEGIN {print $USERS_PER_SEC*$TIME_IN_SEC; exit}")" >> $GITHUB_OUTPUT
+
       - name: Calculate and Store Memory Usage Total For Active User Sessions
         uses: ./.github/actions/prometheus-metrics-calc
         with:
           input: memory_create_sessions
-          performedTestName: 'Testing memory for creating sessions'
-          calculatedMetricName: '500 MB Memory' #as a unit for memory calculation is chosen 500MB memory size to find out how much user sessions so much memory can handle.
-          criteriaName: 'Active User Sessions'
-          criteriaValue: ${{ inputs.numberOfEntitiesInRealm }}
+          performedTestName: 'Memory usage for sessions'
+          calculatedMetricName: 'Active sessions per 500 MB memory' #as a unit for memory calculation is chosen 500MB memory size to find out how much user sessions so much memory can handle.
+          criteriaValue: ${{ steps.active_sessions_count.outputs.active_sessions }}
           isvCPU: false
           isMemory: true
 
@@ -218,8 +224,8 @@ jobs:
         uses: ./.github/actions/prometheus-metrics-calc
         with:
           input: user_logins_vCpu
-          performedTestName: 'Testing CPU usage for user logins'
-          criteriaName: 'User Logins Per Second'
+          performedTestName: 'CPU usage for user logins'
+          calculatedMetricName: 'User Logins per second per 1vCPU'
           criteriaValue: ${{ inputs.numberOfUsersPerSecond }}
           measurementInterval: ${{ inputs.measurement }}
           isvCPU: true
@@ -259,8 +265,8 @@ jobs:
         uses: ./.github/actions/prometheus-metrics-calc
         with:
           input: client_credential_grants_vCpu
-          performedTestName: 'Testing CPU usage for client credential grants'
-          criteriaName: 'Client Credential Grants Per Second'
+          performedTestName: 'CPU usage for client credential grants'
+          calculatedMetricName: 'Client Credential Grants per second per 1vCPU'
           criteriaValue: ${{ inputs.numberOfClientsPerSecond }}
           measurementInterval: ${{ inputs.measurement }}
           isvCPU: true
@@ -287,13 +293,10 @@ jobs:
           name: Calculated environment conclusion
           path: |
             results.json
-            memory_create_sessions
-            user_logins_vCpu
-            client_credential_grants_vCpu
           retention-days: 5
 
       - name: Delete EC2 instances
-        if: ${{ (success() || failure()) && steps.create_aws_ec2_instances.conclusion != 'skipped' }}
+        if: ${{ always() && steps.create_aws_ec2_instances.conclusion != 'skipped' }}
         uses: ./.github/actions/ec2-delete-instances
         with:
           region: ${{ inputs.region }}

--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -141,6 +141,13 @@ jobs:
         with:
           region: ${{ inputs.region }}
 
+      - name: Run Memory Usage Total Query Before Benchmark
+        uses: ./.github/actions/prometheus-run-queries
+        with:
+          project: ${{ env.PROJECT }}
+          runMemoryUsageTotal: true
+          output: memory_create_sessions
+
       - name: Testing memory for creating sessions
         id: kcb-authorization-code-1
         run: |
@@ -155,7 +162,33 @@ jobs:
           --users-per-realm=${{ inputs.numberOfEntitiesInRealm }} \
           --log-http-on-failure \
           --sla-error-percentage=0.001
+        continue-on-error: true
         working-directory: ansible
+
+      - name: Run Memory Usage Total Query After Benchmark
+        uses: ./.github/actions/prometheus-run-queries
+        with:
+          project: ${{ env.PROJECT }}
+          runMemoryUsageTotal: true
+          output: memory_create_sessions
+
+      - name: Calculate and Store Memory Usage Total For Active User Sessions
+        uses: ./.github/actions/prometheus-metrics-calc
+        with:
+          input: memory_create_sessions
+          performedTestName: 'Testing memory for creating sessions'
+          calculatedMetricName: '500 MB Memory' #as a unit for memory calculation is chosen 500MB memory size to find out how much user sessions so much memory can handle.
+          criteriaName: 'Active User Sessions'
+          criteriaValue: ${{ inputs.numberOfEntitiesInRealm }}
+          isvCPU: false
+          isMemory: true
+
+      - name: Run CPU sec Util Query Before Benchmark
+        uses: ./.github/actions/prometheus-run-queries
+        with:
+          project: ${{ env.PROJECT }}
+          runCpuSecsUtil: true
+          output: user_logins_vCpu
 
       - name: Testing CPU usage for user logins
         id: kcb-authorization-code-2
@@ -171,7 +204,33 @@ jobs:
           --users-per-realm=${{ inputs.numberOfEntitiesInRealm }} \
           --log-http-on-failure \
           --sla-error-percentage=0.001
+        continue-on-error: true
         working-directory: ansible
+
+      - name: Run CPU sec Util Query After Benchmark
+        uses: ./.github/actions/prometheus-run-queries
+        with:
+          project: ${{ env.PROJECT }}
+          runCpuSecsUtil: true
+          output: user_logins_vCpu
+
+      - name: Calculate and Store CPU sec Util For Ran Benchmark
+        uses: ./.github/actions/prometheus-metrics-calc
+        with:
+          input: user_logins_vCpu
+          performedTestName: 'Testing CPU usage for user logins'
+          criteriaName: 'User Logins Per Second'
+          criteriaValue: ${{ inputs.numberOfUsersPerSecond }}
+          measurementInterval: ${{ inputs.measurement }}
+          isvCPU: true
+          isMemory: false
+
+      - name: Run CPU sec Util Query Before Benchmark
+        uses: ./.github/actions/prometheus-run-queries
+        with:
+          project: ${{ env.PROJECT }}
+          runCpuSecsUtil: true
+          output: client_credential_grants_vCpu
 
       - name: Testing CPU usage for client credential grants
         id: kcb-client-secret
@@ -186,7 +245,26 @@ jobs:
           --users-per-realm=${{ inputs.numberOfEntitiesInRealm }} \
           --log-http-on-failure \
           --sla-error-percentage=0.001
+        continue-on-error: true
         working-directory: ansible
+
+      - name: Run CPU sec Util Query After Benchmark
+        uses: ./.github/actions/prometheus-run-queries
+        with:
+          project: ${{ env.PROJECT }}
+          runCpuSecsUtil: true
+          output: client_credential_grants_vCpu
+
+      - name: Calculate and Store CPU usage For Ran Benchmark
+        uses: ./.github/actions/prometheus-metrics-calc
+        with:
+          input: client_credential_grants_vCpu
+          performedTestName: 'Testing CPU usage for client credential grants'
+          criteriaName: 'Client Credential Grants Per Second'
+          criteriaValue: ${{ inputs.numberOfClientsPerSecond }}
+          measurementInterval: ${{ inputs.measurement }}
+          isvCPU: true
+          isMemory: false
 
       - name: Archive Gatling reports
         if: ${{ always() }}
@@ -201,6 +279,17 @@ jobs:
         with:
           name: summary
           path: ansible/files/benchmark/*/results/*/js/stats.json
+          retention-days: 5
+
+      - name: Archive Calculated Metrics summary
+        uses: actions/upload-artifact@v3
+        with:
+          name: Calculated environment conclusion
+          path: |
+            results.json
+            memory_create_sessions
+            user_logins_vCpu
+            client_credential_grants_vCpu
           retention-days: 5
 
       - name: Delete EC2 instances

--- a/doc/benchmark/modules/ROOT/pages/report/rosa-benchmark-key-results.adoc
+++ b/doc/benchmark/modules/ROOT/pages/report/rosa-benchmark-key-results.adoc
@@ -73,11 +73,11 @@ Observations:
 This assumes that each user connects to only one client.
 Memory requirements increase with the number of client sessions per user session (not tested yet).
 
-* For each 45 user logins per second, 1 vCPU per Pod in a three-node cluster (tested with up to 300 per second).
+* For each 40 user logins per second, 1 vCPU per Pod in a three-node cluster (tested with up to 300 per second).
 +
 Keycloak spends most of the CPU time hashing the password provided by the user.
 
-* For each 250 client credential grants per second, 1 vCPU per Pod in a three node cluster (tested with up to 2000 per second).
+* For each 450 client credential grants per second, 1 vCPU per Pod in a three node cluster (tested with up to 2000 per second).
 +
 Most CPU time goes into creating new TLS connections, as each client runs only a single request.
 
@@ -90,24 +90,24 @@ Performance of Keycloak dropped significantly when its Pods were throttled in ou
 Target size:
 
 * 50,000 active user sessions
-* 45 logins per seconds
-* 250 client credential grants per second
+* 40 logins per seconds
+* 450 client credential grants per second
 
 Limits calculated:
 
 * CPU requested: 2 vCPU
 +
-(45 logins per second = 1 vCPU, 250 client credential grants per second = 1 vCPU)
+(40 logins per second = 1 vCPU, 450 client credential grants per second = 1 vCPU)
 
 * CPU limit: 6 vCPU
 +
 (Allow for three times the CPU requested to handle peaks, startups and failover tasks, and also refresh token handling which we don't have numbers on, yet)
 
-* Memory requested: 1.2 GB
+* Memory requested: 1.25 GB
 +
-(1 GB base memory plus 200 MB RAM for 50,000 active sessions)
+(1 GB base memory plus 250 MB RAM for 50,000 active sessions)
 
-* Memory limit: 2.2 GB
+* Memory limit: 2.25 GB
 +
 (adding 1 GB to the memory requested)
 


### PR DESCRIPTION
PR contains:
1) Created 2 new actions for performing prometheus queries and calculating/storing result numbers into JSON file;
2) besides the result json file I am publishing the intermediate files with metric numbers before /after benchmark execution, for being able to debug the correctness of numbers before merging the PR;
3) I have added "continue-on-error": true to benchmark execution steps, as sometimes Gatling gives failure during report generation (if some of conditions doesn't met) and the whole workflow fails, even though the metrics can be taken and can be calculated
4) fixed if conditions on action steps as the steps were working no matter if condition was met or not;

The workflow execution for 5 minutes gives the following JSON:
```
{
  "Testing memory for creating sessions": {
    "500 MB Memory per pod in 3 node cluster handles:": "114831 Active User Sessions"
  },
  "Testing CPU usage for user logins": {
    "1vCPU per pod in 3 node cluster handles:": "45 User Logins Per Second"
  },
  "Testing CPU usage for client credential grants": {
    "1vCPU per pod in 3 node cluster handles:": "478 Client Credential Grants Per Second"
  }
}
```

Closes #444