### PR TITLE
fix the missing namespace in widget filters for PostgreSQL DB widgets

### DIFF
--- a/provision/minikube/monitoring/dashboards/keycloak-perf-tests.json
+++ b/provision/minikube/monitoring/dashboards/keycloak-perf-tests.json
@@ -2386,7 +2386,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2491,7 +2492,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2603,7 +2605,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2715,7 +2718,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2832,7 +2836,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2937,7 +2942,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3048,7 +3054,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3105,7 +3112,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(pg_settings_max_connections) by (server)",
+          "expr": "sum(pg_settings_max_connections{namespace=\"${namespace}\"}) by (server)",
           "hide": false,
           "legendFormat": "max connections",
           "range": true,
@@ -3117,7 +3124,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "pg_stat_activity_count{datname=\"keycloak\"} > 0",
+          "expr": "pg_stat_activity_count{datname=\"keycloak\",namespace=\"${namespace}\"} > 0",
           "format": "time_series",
           "hide": false,
           "legendFormat": "{{state}}",
@@ -3130,7 +3137,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(pg_stat_activity_count{datname!=\"keycloak\"}) > 0",
+          "expr": "sum(pg_stat_activity_count{datname!=\"keycloak\",namespace=\"${namespace}\"}) > 0",
           "hide": false,
           "legendFormat": "other db connections",
           "range": true,
@@ -3183,7 +3190,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3224,7 +3232,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "100 * (rate(pg_stat_database_blks_hit{datname=\"keycloak\"}[$__rate_interval]) /\n((rate(pg_stat_database_blks_hit{datname=\"keycloak\"}[$__rate_interval]) +\nrate(pg_stat_database_blks_read{datname=\"keycloak\"}[$__rate_interval]))>0))",
+          "expr": "100 * (rate(pg_stat_database_blks_hit{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval]) /\n((rate(pg_stat_database_blks_hit{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval]) +\nrate(pg_stat_database_blks_read{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval]))>0))",
           "legendFormat": "cache hit rate",
           "range": true,
           "refId": "A"
@@ -3276,7 +3284,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3317,7 +3326,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(pg_stat_bgwriter_checkpoints_req[5m]) /\n(rate(pg_stat_bgwriter_checkpoints_req[5m]) + rate(pg_stat_bgwriter_checkpoints_timed[5m])) * 100",
+          "expr": "rate(pg_stat_bgwriter_checkpoints_req{namespace=\"${namespace}\"}[5m]) /\n(rate(pg_stat_bgwriter_checkpoints_req{namespace=\"${namespace}\"}[5m]) + rate(pg_stat_bgwriter_checkpoints_timed{namespace=\"${namespace}\"}[5m])) * 100",
           "legendFormat": "requested checkpoint rate",
           "range": true,
           "refId": "A"
@@ -3369,7 +3378,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3410,7 +3420,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(pg_stat_database_deadlocks{datname=\"keycloak\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_deadlocks{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval])",
           "legendFormat": "{{pod}} : pg_stat_db_deadlocks",
           "range": true,
           "refId": "A"
@@ -3462,7 +3472,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3503,7 +3514,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(pg_locks_waiting_count{job=\"postgres-exporter\", datname=\"keycloak\"}) without (mode)",
+          "expr": "sum(pg_locks_waiting_count{job=\"postgres-exporter\", datname=\"keycloak\",namespace=\"${namespace}\"}) without (mode)",
           "legendFormat": "{{pod}} : pg_locks_waiting_count",
           "range": true,
           "refId": "A"

--- a/provision/openshift/monitoring/dashboards/keycloak-perf-tests.json
+++ b/provision/openshift/monitoring/dashboards/keycloak-perf-tests.json
@@ -3192,7 +3192,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(pg_settings_max_connections) by (server)",
+          "expr": "sum(pg_settings_max_connections{namespace=\"${namespace}\"}) by (server)",
           "hide": false,
           "legendFormat": "max connections",
           "range": true,
@@ -3204,7 +3204,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "pg_stat_activity_count{datname=\"keycloak\"} > 0",
+          "expr": "pg_stat_activity_count{datname=\"keycloak\",namespace=\"${namespace}\"} > 0",
           "format": "time_series",
           "hide": false,
           "legendFormat": "{{state}}",
@@ -3217,7 +3217,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(pg_stat_activity_count{datname!=\"keycloak\"}) > 0",
+          "expr": "sum(pg_stat_activity_count{datname!=\"keycloak\",namespace=\"${namespace}\"}) > 0",
           "hide": false,
           "legendFormat": "other db connections",
           "range": true,
@@ -3315,7 +3315,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "100 * (rate(pg_stat_database_blks_hit{datname=\"keycloak\"}[$__rate_interval]) /\n((rate(pg_stat_database_blks_hit{datname=\"keycloak\"}[$__rate_interval]) +\nrate(pg_stat_database_blks_read{datname=\"keycloak\"}[$__rate_interval]))>0))",
+          "expr": "100 * (rate(pg_stat_database_blks_hit{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval]) /\n((rate(pg_stat_database_blks_hit{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval]) +\nrate(pg_stat_database_blks_read{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval]))>0))",
           "legendFormat": "cache hit rate",
           "range": true,
           "refId": "A"
@@ -3412,7 +3412,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(pg_stat_bgwriter_checkpoints_req[5m]) /\n(rate(pg_stat_bgwriter_checkpoints_req[5m]) + rate(pg_stat_bgwriter_checkpoints_timed[5m])) * 100",
+          "expr": "rate(pg_stat_bgwriter_checkpoints_req{namespace=\"${namespace}\"}[5m]) /\n(rate(pg_stat_bgwriter_checkpoints_req{namespace=\"${namespace}\"}[5m]) + rate(pg_stat_bgwriter_checkpoints_timed{namespace=\"${namespace}\"}[5m])) * 100",
           "legendFormat": "requested checkpoint rate",
           "range": true,
           "refId": "A"
@@ -3509,7 +3509,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(pg_stat_database_deadlocks{datname=\"keycloak\"}[$__rate_interval])",
+          "expr": "rate(pg_stat_database_deadlocks{datname=\"keycloak\",namespace=\"${namespace}\"}[$__rate_interval])",
           "legendFormat": "{{pod}} : pg_stat_db_deadlocks",
           "range": true,
           "refId": "A"
@@ -3606,7 +3606,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(pg_locks_waiting_count{job=\"postgres-exporter\", datname=\"keycloak\"}) without (mode)",
+          "expr": "sum(pg_locks_waiting_count{job=\"postgres-exporter\", datname=\"keycloak\",namespace=\"${namespace}\"}) without (mode)",
           "legendFormat": "{{pod}} : pg_locks_waiting_count",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
applied to both minikube and OpenShift deployments and they seem to work as excepted now, even when there are multiple Keycloak namespaces deployed to the same K8s cluster