### PR TITLE
Retry Aurora VPC delete in the event that dependencies are still bein…

### DIFF
--- a/provision/aws/rds/aurora_delete.sh
+++ b/provision/aws/rds/aurora_delete.sh
@@ -47,5 +47,11 @@ if [ -n "${AURORA_SECURITY_GROUP_ID}" ]; then
   aws ec2 delete-security-group --group-id ${AURORA_SECURITY_GROUP_ID}
 fi
 
-# Delete the Aurora VPC
-aws ec2 delete-vpc --vpc-id ${AURORA_VPC}
+# Delete the Aurora VPC, retrying 5 times in case that dependencies are not removed instantly
+n=0
+until [ "$n" -ge 5 ]
+do
+   aws ec2 delete-vpc --vpc-id ${AURORA_VPC} && break
+   n=$((n+1))
+   sleep 10
+done


### PR DESCRIPTION
Hopefully should fix failures similar to https://github.com/keycloak/keycloak-benchmark/actions/runs/6016418146/job/16320388452.

I inspected the AWS console this morning and the VPC had no dependencies, so I believe this is a timing issue.