### PR TITLE
Configure site name in Keycloak

### DIFF
--- a/provision/minikube/keycloak/config/kcb-infinispan-cache-remote-store-config.xml
+++ b/provision/minikube/keycloak/config/kcb-infinispan-cache-remote-store-config.xml
@@ -24,7 +24,7 @@
 
     <!-- the statistics="true" attribute is not part of the original KC config and was added by Keycloak Benchmark -->
     <cache-container name="keycloak" statistics="true">
-        <transport lock-timeout="60000" site="ISPN"/>
+        <transport lock-timeout="60000"/>
         <metrics names-as-tags="true" />
         <local-cache name="realms" simple-cache="true" statistics="true">
             <encoding>

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -216,6 +216,9 @@ spec:
                   -Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false
                   -XX:FlightRecorderOptions=stackdepth=512
 {{- end }}
+{{- if .Values.infinispan.site }}
+                  -Djboss.site.name={{.Values.infinispan.site}}
+{{- end}}
             ports:
 {{ if .Values.otel }}
               - containerPort: 9464

--- a/provision/rosa-cross-dc/Taskfile.yaml
+++ b/provision/rosa-cross-dc/Taskfile.yaml
@@ -142,6 +142,7 @@ tasks:
         --set infinispan.remoteStore.port=11222
         --set infinispan.remoteStore.username=developer
         --set infinispan.remoteStore.password={{ .RS_HOT_ROD_PASSWORD }}
+        --set infinispan.site={{ .ROSA_CLUSTER_NAME }}
         --set cryostat={{ .KC_CRYOSTAT }}
         --set sqlpad=false
         --set environment=openshift


### PR DESCRIPTION
* Added 'jboss.site.name' property
* Removed 'site' attribute from Infinispan configuration

Need to test it in Openshift but I'm expecting to see a log entry like: `[org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (main) Node name: pedro-desktop-30198, Site name: my-site` with the proper site's name.

I saw usage of the site name in the events triggered by the work cache and some sessions/login failures cache.