### PR TITLE
Replace file: /path, with file:///path, to make it a clickable link in bash

### DIFF
--- a/benchmark/src/main/content/bin/kcb.sh
+++ b/benchmark/src/main/content/bin/kcb.sh
@@ -114,6 +114,10 @@ CLASSPATH_OPTS="$DIRNAME/../lib/*"
 
 declare -A RESULT_CACHE
 
+rewrite_output() {
+    cat | sed 's|Please open the following file: |Please open the following file://|g' < /dev/stdin 
+}
+
 run_benchmark_with_workload() {
   if [[ -v RESULT_CACHE[$2] ]]; then
       echo "INFO: Keycloak benchmark was already running for $1=$2 with result ${RESULT_CACHE[$2]}."
@@ -128,7 +132,7 @@ run_benchmark_with_workload() {
   if [ "$MODE" = "incremental" ]; then
     java $JAVA_OPTS "${SERVER_OPTS[@]}" "${CONFIG_ARGS[@]}" "-D$1=$2" "-Dmeasurement=${3:-30}" -cp $CLASSPATH_OPTS io.gatling.app.Gatling -bf $DIRNAME -rf "$OUTPUT_DIR" -s $SCENARIO > "$OUTPUT_DIR/gatling.log" 2>&1
   else
-    java $JAVA_OPTS "${SERVER_OPTS[@]}" "${CONFIG_ARGS[@]}" "-D$1=$2" "-Dmeasurement=${3:-30}" -cp $CLASSPATH_OPTS io.gatling.app.Gatling -bf $DIRNAME -rf "$OUTPUT_DIR" -s $SCENARIO 2>&1 | tee "$OUTPUT_DIR/gatling.log"
+    java $JAVA_OPTS "${SERVER_OPTS[@]}" "${CONFIG_ARGS[@]}" "-D$1=$2" "-Dmeasurement=${3:-30}" -cp $CLASSPATH_OPTS io.gatling.app.Gatling -bf $DIRNAME -rf "$OUTPUT_DIR" -s $SCENARIO | rewrite_output 2>&1 | tee "$OUTPUT_DIR/gatling.log"
   fi
   EXIT_RESULT=$?
   # don't include URLs or password information into the configuration recorded


### PR DESCRIPTION
A bit hacky, but it works. Don't know a better way to do it since Gatling is what prints the statement.