### PR TITLE
Update Infinispan image to 14.0.15.Final

### DIFF
--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -31,9 +31,7 @@ metadata:
     infinispan.org/monitoring: 'true'
 spec:
   configMapName: "cluster-config"
-  {{- if .Values.image }}
-  image: {{ .Values.image }}
-  {{- end }}
+  image: {{ .Values.image | default .Values.defaultImage }}
   configListener:
     enabled: false
   replicas: {{ .Values.replicas }}

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 replicas: 3
+defaultImage: quay.io/infinispan/server:14.0.15.Final
 cacheDefaults:
   owners: 2
   crossSiteMode: SYNC


### PR DESCRIPTION
```
$ oc -n pruivo1-infinispan logs infinispan-0 | grep -E "(ISPN000439|ISPN000094|ISPN080001)"
09:47:07,513 INFO  (main) [org.infinispan.CLUSTER] ISPN000094: Received new cluster view for channel ISPN: [infinispan-0-40119|0] (1) [infinispan-0-40119]
09:47:07,616 INFO  (jgroups-6,infinispan-0-40119) [org.infinispan.XSITE] ISPN000439: Received new cross-site view: [pruivo1-infinispan, pruivo2-infinispan]
09:47:08,694 INFO  (main) [org.infinispan.SERVER] ISPN080001: Infinispan Server 14.0.15.Final started in 5900ms
09:47:32,618 INFO  (jgroups-5,infinispan-0-40119) [org.infinispan.CLUSTER] ISPN000094: Received new cluster view for channel ISPN: [infinispan-0-40119|1] (2) [infinispan-0-40119, infinispan-1-27400]
```
```
$ oc -n pruivo2-infinispan logs infinispan-0 | grep -E "(ISPN000439|ISPN000094|ISPN080001)"
09:46:56,398 INFO  (main) [org.infinispan.CLUSTER] ISPN000094: Received new cluster view for channel ISPN: [infinispan-0-34993|0] (1) [infinispan-0-34993]
09:46:57,495 INFO  (main) [org.infinispan.SERVER] ISPN080001: Infinispan Server 14.0.15.Final started in 5763ms
09:46:58,438 INFO  (jgroups-6,infinispan-0-34993) [org.infinispan.XSITE] ISPN000439: Received new cross-site view: [pruivo2-infinispan]
09:47:07,596 INFO  (jgroups-5,infinispan-0-34993) [org.infinispan.XSITE] ISPN000439: Received new cross-site view: [pruivo1-infinispan, pruivo2-infinispan]
09:47:32,162 INFO  (jgroups-5,infinispan-0-34993) [org.infinispan.CLUSTER] ISPN000094: Received new cluster view for channel ISPN: [infinispan-0-34993|1] (2) [infinispan-0-34993, infinispan-1-354]
```