### PR TITLE
close http connections explicitly

### DIFF
--- a/benchmark/src/main/java/org/keycloak/benchmark/Config.java
+++ b/benchmark/src/main/java/org/keycloak/benchmark/Config.java
@@ -130,6 +130,7 @@ public class Config {
      */
     public static final int badLoginCount = Integer.getInteger("bad-login-count", 0);
 
+
     /**
      * If tests should infer HTML resources and include steps to fetch them automatically.
      */
@@ -148,6 +149,8 @@ public class Config {
      * when the local testing system is overtaxed.  But this will induce a lesser load than real world.
      */
     public static final boolean shareConnections = Boolean.getBoolean("share-connections");
+    public static final boolean closeHttpConnection = Boolean.getBoolean("close-http-connection");
+    public static final boolean httpProxy = Boolean.getBoolean("http-proxy");
 
     public static final boolean useAllLocalAddresses = Boolean.getBoolean("use-all-local-addresses");
 

--- a/benchmark/src/main/java/org/keycloak/benchmark/Config.java
+++ b/benchmark/src/main/java/org/keycloak/benchmark/Config.java
@@ -144,12 +144,13 @@ public class Config {
      */
     public static final int refreshTokenCount = Integer.getInteger("refresh-token-count", 0);
 
+    public static final boolean refreshCloseHttpConnection = Boolean.getBoolean(System.getProperty("refresh-close-http-connection", "true"));
+
     /**
      * Whether to share TCP connections among the multiple users in the test scenario, possibly helpful
      * when the local testing system is overtaxed.  But this will induce a lesser load than real world.
      */
     public static final boolean shareConnections = Boolean.getBoolean("share-connections");
-    public static final boolean closeHttpConnection = Boolean.getBoolean("close-http-connection");
     public static final boolean httpProxy = Boolean.getBoolean("http-proxy");
 
     public static final boolean useAllLocalAddresses = Boolean.getBoolean("use-all-local-addresses");

--- a/benchmark/src/main/scala/keycloak/scenario/CommonSimulation.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/CommonSimulation.scala
@@ -2,7 +2,7 @@ package keycloak.scenario
 
 import io.gatling.commons.validation.Validation
 import io.gatling.core.Predef._
-import io.gatling.http.Predef.http
+import io.gatling.http.Predef.{http, Proxy}
 import org.keycloak.benchmark.gatling.log.LogProcessor
 import org.keycloak.benchmark.Config
 import org.keycloak.benchmark.WorkloadModel
@@ -27,6 +27,12 @@ abstract class CommonSimulation extends Simulation {
     var default = http
       .acceptHeader("application/json")
       .disableFollowRedirect
+
+    if (Config.httpProxy) {
+
+      default = default.proxy(Proxy("127.0.0.1", 8888))
+
+    }
 
     if (Config.shareConnections) {
       // When a local system cannot handle a large number of connections, using shared connections

--- a/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
+++ b/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala
@@ -723,8 +723,12 @@ class KeycloakScenarioBuilder {
   }
 
   private def refreshToken(): ChainBuilder = {
-    doIfOrElse(Config.closeHttpConnection) {
-      exec(http("RefreshTokenWithNewHTTPConnection")
+    doIfOrElse(Config.refreshCloseHttpConnection) {
+      // In the real world a token refresh will need to start a new HTTP connection before the request.
+      // This simulates the behavior in the load test by closing the connection after the request, so that the next
+      // request will need to create a new connection. This assumes that a scenario will issue multiple refreshes
+      // in the scenario, or at lest have one more request after this refresh, like a logout.
+      exec(http("RefreshTokenAndCloseHttpConnection")
         .post(TOKEN_ENDPOINT)
         .headers(UI_HEADERS)
         .formParam("grant_type", "refresh_token")

--- a/doc/benchmark/modules/ROOT/pages/configuration.adoc
+++ b/doc/benchmark/modules/ROOT/pages/configuration.adoc
@@ -267,6 +267,11 @@ Used in xref:scenario/authorization-code.adoc[].
 | Number of token refreshes after logging in.
 Used in xref:scenario/authorization-code.adoc[].
 
+| [.nowrap]`--refresh-close-http-connection`
+| `true`
+| Close the HTTP connection after a token refresh.
+Used in xref:scenario/authorization-code.adoc[].
+
 | [[basic-url]][.nowrap]`--basic-url`
 | (not set)
 | URL to be called in the xref:scenario/basic-get.adoc[].

--- a/doc/benchmark/modules/ROOT/pages/configuration.adoc
+++ b/doc/benchmark/modules/ROOT/pages/configuration.adoc
@@ -104,6 +104,12 @@ Will log a lot of information.
 Use this only during development.
 Never use it during a load test as it slows down Gatling.
 
+| [.nowrap]`--http-proxy`
+| (not set)
+| If set, will proxy all HTTP requests to a proxy tool of your choice and the current default proxy host and port are `127.0.0.1`, `8888` respectively. These are currently not configurable.
+
+Never use it during a load test as it slows down Gatling to be able to proxy the requests to a proxy client and comes with the usual proxy nuances that we have to be careful, in general.
+
 | [.nowrap]`--sla-error-percentage`
 | `0`
 | Maximum percentage of requests to fail during a run.

--- a/doc/benchmark/modules/ROOT/pages/scenario/authorization-code.adoc
+++ b/doc/benchmark/modules/ROOT/pages/scenario/authorization-code.adoc
@@ -49,7 +49,7 @@ bin/kcb.sh \
 
 To create offline sessions, set the parameter xref:configuration.adoc#scope[`--scope`] to a value including `offline_access`, for example, `openid profile offline_access`.
 
-To test repeated refreshing of tokens between authenticating and logging out, pass `--refresh-token-count=<count>` and `--refresh-token-period=<seconds>`.
+To test repeated refreshing of tokens between authenticating and logging out, pass `--refresh-token-count=<count>` and `--refresh-token-period=<seconds>`. And pass in the additional optional argument `--close-http-connection=true` to test with a new http connection for the refresh token endpoint every time, we also should see the Request name in the metadata to be `RefreshTokenWithNewHTTPConnection` instead of `RefreshToken`, when `--close-http-connection=true` is in use.
 
 == Error messages
 

--- a/doc/benchmark/modules/ROOT/pages/scenario/authorization-code.adoc
+++ b/doc/benchmark/modules/ROOT/pages/scenario/authorization-code.adoc
@@ -49,7 +49,9 @@ bin/kcb.sh \
 
 To create offline sessions, set the parameter xref:configuration.adoc#scope[`--scope`] to a value including `offline_access`, for example, `openid profile offline_access`.
 
-To test repeated refreshing of tokens between authenticating and logging out, pass `--refresh-token-count=<count>` and `--refresh-token-period=<seconds>`. And pass in the additional optional argument `--close-http-connection=true` to test with a new http connection for the refresh token endpoint every time, we also should see the Request name in the metadata to be `RefreshTokenWithNewHTTPConnection` instead of `RefreshToken`, when `--close-http-connection=true` is in use.
+To test repeated refreshing of tokens between authenticating and logging out, pass `--refresh-token-count=<count>` and `--refresh-token-period=<seconds>`.
+By default, it will close the HTTP connection so that the next request needs to establish a new connection, simulating the behavior of a client where refreshing of token usually happens after the previous connection to Keycloak has already expired.
+Change this behavior by adding the option `--refresh-close-http-connection=false`.
 
 == Error messages
 


### PR DESCRIPTION
- Updated the Refresh Token scenario to optionally use `"Connection": "close"` for the refresh token endpoint
- Also adding a new way to look at the http requests sent using external proxy client with `--http-proxy` cli argument

fixes #518 