### PR TITLE
Make Infinispan failure detection timeout configurable

### DIFF
--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -76,6 +76,8 @@ tasks:
       CROSS_DC_JVM_OPTS: '{{.CROSS_DC_JVM_OPTS}}'
       CROSS_DC_LOCAL_GOSSIP_ROUTER: '{{.CROSS_DC_LOCAL_GOSSIP_ROUTER | default "true"}}'
       CROSS_DC_REMOTE_GOSSIP_ROUTER: '{{.CROSS_DC_REMOTE_GOSSIP_ROUTER | default "true"}}'
+      CROSS_DC_FD_INTERVAL: '{{.CROSS_DC_FD_INTERVAL | default "2000"}}'
+      CROSS_DC_FD_TIMEOUT: '{{.CROSS_DC_FD_TIMEOUT | default "10000"}}'
     cmds:
       - >
         KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" helm upgrade --install infinispan --namespace {{.NAMESPACE}}
@@ -100,6 +102,8 @@ tasks:
         --set cacheDefaults.crossSiteMode={{.CROSS_DC_MODE}}
         --set cacheDefaults.stateTransferMode={{.CROSS_DC_STATE_TRANSFER_MODE}}
         --set image={{.CROSS_DC_IMAGE}}
+        --set fd.interval={{.CROSS_DC_FD_INTERVAL}}
+        --set fd.timeout={{.CROSS_DC_FD_TIMEOUT}}
         ./ispn-helm
     preconditions:
       - test -f ".task/kubecfg/{{.ROSA_CLUSTER_NAME}}"

--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -36,7 +36,7 @@ spec:
     enabled: false
   replicas: {{ .Values.replicas }}
   container:
-    extraJvmOpts: '-Dorg.infinispan.openssl=false -Dinfinispan.cluster.name=ISPN {{.Values.jvmOptions}}'
+    extraJvmOpts: '-Dorg.infinispan.openssl=false -Dinfinispan.cluster.name=ISPN {{.Values.jvmOptions}} -Djgroups.xsite.fd.interval={{.Values.fd.interval}} -Djgroups.xsite.fd.timeout={{.Values.fd.timeout}}'
     {{- if .Values.cpu }}
     cpu: {{ .Values.cpu }}
     {{- end}}

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -40,3 +40,6 @@ logging:
 hotrodPassword: changeme
 metrics:
   histograms: false
+fd:
+  interval: 2000
+  timeout: 10000


### PR DESCRIPTION
Defaults: 10 sec with 2 sec heartbeat interval (suspected after 5 heartbeats lost)

Fixes #532