### PR TITLE
basic python script to generate PDFs of the dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 gatling-charts-highcharts-bundle-3.4.2
 gatling-charts-*
 
+# Grafana report pdfs
+benchmark/src/main/python/grafana_report_pdfs
+
 # Intellij
 ###################
 .idea

--- a/ansible/benchmark.sh
+++ b/ansible/benchmark.sh
@@ -9,6 +9,10 @@ CLUSTER_NAME=${CLUSTER_NAME:-"benchmark_$(whoami)"}
 
 if [ -f "env.yml" ]; then ANSIBLE_CUSTOM_VARS_ARG="-e @env.yml"; fi
 
+GRAFANA_FROM_DATE_UNIX_MS=$(date +%s%3N)
 ansible-playbook -i ${CLUSTER_NAME}_${REGION}_inventory.yml benchmark.yml \
   $ANSIBLE_CUSTOM_VARS_ARG \
-  -e "kcb_params=\"${KCB_PARAMS}\""
+  -e "kcb_params=\"${KCB_PARAMS}\"" || true
+GRAFANA_TO_DATE_UNIX_MS=$(date +%s%3N)
+SNAP_GRAFANA_TIME_WINDOW="from=${GRAFANA_FROM_DATE_UNIX_MS}&to=${GRAFANA_TO_DATE_UNIX_MS}"
+echo "INFO: Input for snapGrafana.py is ${SNAP_GRAFANA_TIME_WINDOW}"

--- a/benchmark/src/main/content/bin/kcb.sh
+++ b/benchmark/src/main/content/bin/kcb.sh
@@ -115,7 +115,7 @@ CLASSPATH_OPTS="$DIRNAME/../lib/*"
 declare -A RESULT_CACHE
 
 rewrite_output() {
-    cat | sed 's|Please open the following file: |Please open the following file://|g' < /dev/stdin 
+    cat | sed 's|Please open the following file: |Please open the following file://|g' < /dev/stdin
 }
 
 run_benchmark_with_workload() {
@@ -126,6 +126,7 @@ run_benchmark_with_workload() {
   local OUTPUT_DIR="${4:-"$DIRNAME/../results/"}"
   echo "INFO: Running benchmark with $1=$2, result output will be available in: $OUTPUT_DIR"
   mkdir -p "$OUTPUT_DIR"
+  GRAFANA_FROM_DATE_UNIX_MS=$(date +%s%3N)
   DATE_START_UNIX=$(date +%s)
   DATE_START_ISO=$(date --iso-8601=seconds)
   DATE_START_ISO_COMPRESSED=$(date '+%Y%m%d-%H%M%S')
@@ -141,6 +142,8 @@ run_benchmark_with_workload() {
   OUTPUT_FOLDER=$OUTPUT_DIR/$(ls $OUTPUT_DIR -Art | grep -- -20 | tail -1)
   DATE_END_UNIX=$(date +%s)
   DATE_END_ISO=$(date --iso-8601=seconds)
+  GRAFANA_TO_DATE_UNIX_MS=$(date +%s%3N)
+  SNAP_GRAFANA_TIME_WINDOW="from=${GRAFANA_FROM_DATE_UNIX_MS}&to=${GRAFANA_TO_DATE_UNIX_MS}"
   jq '{ "grafana_output": { "stats": . } }' $OUTPUT_FOLDER/js/stats.json > $OUTPUT_FOLDER/result_grafana_stats.json
   UUID=$(uuidgen)
   jq '.'  > $OUTPUT_FOLDER/result_grafana_inputs.json <<EOF
@@ -158,6 +161,7 @@ run_benchmark_with_workload() {
       },
       "input": {
         "scenario": "${SCENARIO}",
+        "snap_grafana_time_window": "${SNAP_GRAFANA_TIME_WINDOW}",
         "unit": "$1",
         "value": $2,
         "config": "${CONFIG_ARGS_CLEAN[@]}"

--- a/benchmark/src/main/python/requirements.txt
+++ b/benchmark/src/main/python/requirements.txt
@@ -1,0 +1,4 @@
+playwright==1.37.0
+asyncio==3.4.3
+typing==3.7.4.3
+typing_extensions==4.7.1

--- a/benchmark/src/main/python/snapGrafana.py
+++ b/benchmark/src/main/python/snapGrafana.py
@@ -1,0 +1,135 @@
+import argparse
+import asyncio
+import datetime
+import time
+from typing import Optional
+
+import requests
+from playwright.async_api import async_playwright
+
+
+async def generate_pdf(
+        target_url: str,
+        auth_token: Optional[str],
+        destination_file: str,
+        page_width: int = 1920,
+        margin: int = 80
+) -> None:
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page(device_scale_factor=4)  # You can change the scale_factor to +/- images quality
+        page.set_default_navigation_timeout(120000.0)
+        await page.set_viewport_size({'width': page_width, 'height': 1080})
+        await page.set_extra_http_headers(
+            {'Authorization': f'Bearer {auth_token}'}
+        )
+        await page.goto(target_url)
+        await page.wait_for_selector('.react-grid-layout')
+        page_height = await page.evaluate(
+            'document.getElementsByClassName(\'react-grid-layout\')[0].getBoundingClientRect().bottom;'
+        )
+        await page.set_viewport_size({'width': page_width, 'height': page_height})
+        await page.wait_for_load_state('networkidle')
+        print(f"Navigated to the page, taking PDF now and saving it to {destination_file}")
+        await page.pdf(
+            path=destination_file,
+            scale=1,
+            width=f'{page_width + margin * 2}px',
+            height=f'{page_height + margin * 2}px',
+            display_header_footer=False,
+            print_background=True,
+            margin={
+                'top': f'{margin}px',
+                'bottom': f'{margin}px',
+                'left': f'{margin}px',
+                'right': f'{margin}px',
+            }
+        )
+        time.sleep(1)
+        await browser.close()
+
+
+async def generate_grafana_api_token(dashboard_domain, admin_password):
+    print(f"CREATE GRAFANA API KEY")
+    dttm = get_current_time()
+    url =  f'http://admin:{admin_password}@{dashboard_domain}/api/auth/keys'
+    reqBody = {'name':f'dashboard_pdf_{dttm}','role':'Editor','secondsToLive':86400}
+    auth_token_id = ""
+    auth_token = ""
+    try:
+        response = requests.post(url, json = reqBody)
+        response.raise_for_status()
+        jsonResponse = response.json()
+        #only uncomment to help with debugging, dont push this to a source control repo :)
+        #print(jsonResponse["id"], jsonResponse["key"])
+        auth_token_id = jsonResponse["id"]
+        auth_token = jsonResponse["key"]
+
+    except requests.exceptions.HTTPError as http_err:
+        print(f'HTTP error {http_err.args[0]} occured: {http_err}')
+    except Exception as err:
+        print(f'Other error occured: {err}')
+
+    return (auth_token_id,auth_token)
+
+async def delete_grafana_api_key(dashboard_domain, admin_password, auth_token_id):
+    print(f"DELETE GRAFANA API KEY")
+    url =  f'http://admin:{admin_password}@{dashboard_domain}/api/auth/keys/{auth_token_id}'
+    try:
+        response = requests.delete(url)
+        response.raise_for_status()
+        jsonResponse = response.json()
+        print(jsonResponse)
+
+    except HTTPError as http_err:
+        print(f'HTTP error occured: {http_err}')
+    except Exception as err:
+        print(f'Other error occured: {err}')
+
+def get_current_time():
+    now = datetime.datetime.now()
+    timestamp = now.strftime("%Y%m%d_%H:%M:%S")
+    return timestamp
+
+async def main():
+
+    dttm = get_current_time()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--grafana_domain", help='grafana domain without "http://" ')
+    parser.add_argument("--admin_password", help='Grafana Auth Token')
+    parser.add_argument("--time_window", help='ex: from=1694700191047&to=1694700510513')
+    parser.add_argument("--keycloak_namespace", help='default is runner-keycloak', default="runner-keycloak")
+
+    args = parser.parse_args()
+    admin_password: str = args.admin_password
+    grafana_domain: str = args.grafana_domain
+    keycloak_namespace: str = args.keycloak_namespace
+    time_window: str = args.time_window
+
+    #generate token
+    auth_token = await generate_grafana_api_token(grafana_domain, admin_password)
+
+    dashboards = ['basic-keycloak-dashboard-by-namespace/keycloak-perf-tests', 'Ct9jmJyVz/keycloak-infinispan-board', 'R3kK_894z/authentication-code-slo', 'A0kQZ7u4k/client-credentials-slo']
+    for dashboard in dashboards:
+        dashboard_uid = dashboard.split("/")[-1]
+
+        #conditionally setting the args in the dashboard urls
+        keycloak_perf_tests_url: str =  f'http://{grafana_domain}/d/{dashboard}?orgId=1&var-namespace={keycloak_namespace}&{time_window}'
+
+        if(dashboard_uid == 'authentication-code-slo' or dashboard_uid == 'client-credentials-slo'):
+            keycloak_perf_tests_url = keycloak_perf_tests_url+f'&var-pod_name=All'
+        elif(dashboard_uid == 'keycloak-infinispan-board'):
+            keycloak_perf_tests_url = keycloak_perf_tests_url+f'&var-local_cache=All&var-distributed_cache=All'
+
+        #defining the dashboard pdf file name
+        destination_file: str = f'./grafana_report_pdfs/{dttm}/{dashboard.split("/")[-1]}.pdf'
+
+        #print pdf
+        await generate_pdf(keycloak_perf_tests_url, auth_token[1], destination_file)
+
+    #delete token
+    await delete_grafana_api_key(grafana_domain, admin_password, auth_token[0])
+
+asyncio.run(main())

--- a/doc/kubernetes/modules/ROOT/pages/util/grafana.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/util/grafana.adoc
@@ -22,9 +22,109 @@ image::util/grafana.png[]
 
 == Adding custom dashboards
 
-Login to Grafana with the username `admin` and the password `keycloak` when anonymous login is not sufficient.
+Login to Grafana with the username `admin` and the password `keycloak` or the password relevant to your deployment when anonymous login is not sufficient.
 
 Custom dashboards are included in folder `monitoring/dashboards`.
 Add more dashboards there as new files, and `task` installs the latest versions in the minikube cluster.
 
+== Taking dashboard snapshots
 
+Once logged in to Grafana with the username `admin` and the password relevant to the deployment, the user would have the ability to take snapshots of the dashboards and export the snapshots as a json file to be able to import them into a standalone Grafana instance to view and interact with the dashboard.
+
+You can read on more on how to take the snapshot and other ways to share a dashboard https://grafana.com/docs/grafana/latest/dashboards/share-dashboards-panels/#publish-a-snapshot[here].
+
+== Automated dashboard PDF downloads
+
+We have a python script `link:{github-files}/benchmark/src/main/python/snapGrafana.py[snapGrafana.py]` which allows us to take the PDF snapshots of the available dashboards for a given time window, Grafana instance, Kubernetes namespace.
+
+=== Installing needed python libraries
+
+[source,bash]
+----
+pip3 install -U -r requirements.txt
+----
+
+And we can check if all the requirements are satisfied using the below command.
+[source,bash]
+----
+python3 -m pip check
+----
+
+
+NOTE: The playwright python module that's imported needs additional installation using the command `playwright install` if not we would see a exception similar to this.
+
+[source,bash]
+----
+if you see a missing playwright._impl._api_types.Error: Executable doesn't exist at  exception, just run the below command to download the needed browsers for the script to work.
+----
+
+=== Usage
+
+Once the requirements for the script are satisfied, you can use it with the below command and the dashboard pdf's are downloaded to the current directory where you are executing this script from.
+
+[source, bash]
+----
+python3 snapGrafana.py --grafana_domain ${GRAFANA_DOMAIN} \
+--admin_password ${KEYCLOAK_MASTER_PASSWORD} \
+--time_window "from=1694801561166&to=1694802033424" \
+--keycloak_namespace "runner-keycloak"
+----
+
+=== snapGrafana.py cli options
+
+[cols='2,1,5a']
+|===
+| CLI option | Default |Notes
+
+| [.nowrap]`--grafana_domain`
+| (not set)
+| The domain of the Grafana server without the `http://`.
+
+example: `--grafana_domain grafana.apps.gh-keycloak.abcd.xx.openshiftapps.com`
+
+| [.nowrap]`--admin_password`
+| (not set)
+| This is the Grafana Admin user password, if you use minikube deployment its `admin` and if you use openshift its what is set for `KEYCLOAK_MASTER_PASSWORD`
+
+| [.nowrap]`--keycloak_namespace`
+| runner-keycloak
+| The namespace in which the target Keycloak is deployed, this is used by the grafana dashboards to filter.
+
+| [.nowrap]`--time_window`
+| (not set)
+| The time window used by the dashboard to filter the scope of the dashboard.
+
+When using the Ansible module's `benchmark.sh` script, you will find a message like the below at the end of the playbook run.
+
+[source, bash]
+----
+INFO: Input for snapGrafana.py is from=1695382925487&to=1695383025382
+----
+
+When using `kcb.sh` directly, user can get this value from the `result_grafana_inputs.json` file generated after the `kcb.sh` based load simulations and can be found in the `keycloak-benchmark-0.XX-SNAPSHOT/results/` directory. Below is an example output of the `result_grafana_inputs.json` file and the needed time window value is associated with the `snap_grafana_time_window` key.
+
+[source, json]
+----
+{
+  "uuid": "108fdd0c-41b7-41d5-af66-8a41cff19a8f",
+  "name": "Scenario 'keycloak.scenario.authentication.AuthorizationCode' with 2 users-per-sec",
+  "grafana_input": {
+    "start": {
+      "epoch_seconds": 1695213772,
+      "iso": "2023-09-20T08:42:52-04:00"
+    },
+    "end": {
+      "epoch_seconds": 1695213810,
+      "iso": "2023-09-20T08:43:30-04:00"
+    },
+    "input": {
+      "scenario": "keycloak.scenario.authentication.AuthorizationCode",
+      "snap_grafana_time_window": "from=1695213772731&to=1695213810554",
+      "unit": "users-per-sec",
+      "value": 2,
+      "config": "-Drealm-name=test-realm"
+    }
+  }
+}
+----
+|===


### PR DESCRIPTION
fixes #543 

- [x] create the pdf generation script from a grafana dashboard.
- [x] add the module to create auth keys on demand and delete them after report generation.
- [x] create a requirements file.
- [x] update docs and explain how to use this script.
- [x] connect the report generation tool with kcb.sh script, output the time_window parameter as part of the kcb.sh run asset.