### PR TITLE
Increase max-replicas on rosa_create_cluster.sh to avoid error during…

### DIFF
--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -92,7 +92,7 @@ echo
 
 SCALING_MACHINE_POOL=$(rosa list machinepools -c "${CLUSTER_NAME}" -o json | jq -r '.[] | select(.id == "scaling") | .id')
 if [[ "${SCALING_MACHINE_POOL}" != "scaling" ]]; then
-    rosa create machinepool -c "${CLUSTER_NAME}" --instance-type m5.4xlarge --max-replicas 0 --min-replicas 0 --name scaling --enable-autoscaling
+    rosa create machinepool -c "${CLUSTER_NAME}" --instance-type m5.4xlarge --max-replicas 10 --min-replicas 0 --name scaling --enable-autoscaling
 fi
 
 ./rosa_efs_create.sh


### PR DESCRIPTION
… creation of cluster

There is following [error](https://github.com/keycloak/keycloak-benchmark/actions/runs/6308269787/job/17126198580) during creation of cluster. This PR increases --max-replicas value in rosa_create_cluster.sh to avoid the `ERR: Failed to add machine pool to cluster 'gh-keycloak': Attribute 'autoscaling.max_replicas' must be a integer greater than 0.`