### PR TITLE
updating the jgroups docs for kc22

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/running/concepts/threads.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/running/concepts/threads.adoc
@@ -35,6 +35,8 @@ To see the error the first time it happens, the system property `jgroups.thread_
 include::partial$executor-jgroups-thread-calculation.adoc[]
 --
 
+We can utilize the `vendor_jgroups_tcp_get_thread_pool_size` metric to monitor the total JGroup threads in the pool and `vendor_jgroups_tcp_get_thread_pool_size_active` for the threads active in the pool. This is useful to monitor, say for instance the above example of keeping the total Keycloak cluster worker threads under the JGroup thread pool of 200.
+
 [#load-shedding]
 === Load Shedding
 

--- a/doc/kubernetes/modules/ROOT/pages/running/concepts/threads.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/running/concepts/threads.adoc
@@ -35,7 +35,8 @@ To see the error the first time it happens, the system property `jgroups.thread_
 include::partial$executor-jgroups-thread-calculation.adoc[]
 --
 
-We can utilize the `vendor_jgroups_tcp_get_thread_pool_size` metric to monitor the total JGroup threads in the pool and `vendor_jgroups_tcp_get_thread_pool_size_active` for the threads active in the pool. This is useful to monitor, say for instance the above example of keeping the total Keycloak cluster worker threads under the JGroup thread pool of 200.
+Use the metrics `vendor_jgroups_tcp_get_thread_pool_size` to monitor the total JGroup threads in the pool and `vendor_jgroups_tcp_get_thread_pool_size_active` for the threads active in the pool.
+This is useful to monitor that limiting the Quarkus thread pool size keeps the number of active JGroup threads below the maximum JGroup thread pool size.
 
 [#load-shedding]
 === Load Shedding


### PR DESCRIPTION
Fixes #553 

@ahus1 looks like the first two points in the ticket are already [updated](https://www.keycloak.org/keycloak-benchmark/kubernetes-guide/latest/running/concepts/threads#jgroup-connection-pool) and let me know if they need to be elaborated any further. 

> - the reduction of Keycloak worker threads to be aligned with the JGroup thread size, as running into retries due to missing threads would still slow down the system
> - setting -Djgroups.thread_dumps_threshold=1 to get notified in the logs when the thread pool is exhausted.

I have added a new paragraph for this below item.
> monitoring the metric vendor_jgroups_tcp_get_thread_pool_size