### PR TITLE
Enable state transfer even if a remote cache is enabled

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/running/keycloak-with-external-infinispan.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/running/keycloak-with-external-infinispan.adoc
@@ -30,8 +30,6 @@ include::example$helm-keycloak-config/kcb-infinispan-cache-remote-store-config.x
 <2> For the address to the remote store, reference two environment variables for host name and port number.
 <3> For authentication, reference two environment variables for username and password.
 <4> To secure the remote store connection, use the Kubernetes mechanisms of the pre-configured truststore.
-<5> New tag `<state-transfer />` to avoid a state transfer on node startup and instead use the remote store.
-This speeds up the startup of new nodes.
 
 .. Prepare an Infinispan Cache configuration XML from the file `cache-ispn.xml` which is part of the Keycloak distribution:
 For each `replicated-cache` entry, add the tag `<persistence />` as shown below.

--- a/provision/minikube/keycloak/config/kcb-infinispan-cache-remote-store-config.xml
+++ b/provision/minikube/keycloak/config/kcb-infinispan-cache-remote-store-config.xml
@@ -71,7 +71,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/> <!--5-->
         </distributed-cache>
         <!--end::keycloak-ispn-remotestore[] -->
         <distributed-cache name="authenticationSessions" owners="2" statistics="true">
@@ -100,7 +99,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/>
         </distributed-cache>
         <distributed-cache name="offlineSessions" owners="2" statistics="true">
             <expiration lifespan="-1"/>
@@ -128,7 +126,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/>
         </distributed-cache>
         <distributed-cache name="clientSessions" owners="2" statistics="true">
             <expiration lifespan="-1"/>
@@ -155,7 +152,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/>
         </distributed-cache>
         <distributed-cache name="offlineClientSessions" owners="2" statistics="true">
             <expiration lifespan="-1"/>
@@ -182,7 +178,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/>
         </distributed-cache>
         <distributed-cache name="loginFailures" owners="2" statistics="true">
             <expiration lifespan="-1"/>
@@ -209,7 +204,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/>
         </distributed-cache>
         <local-cache name="authorization" simple-cache="true" statistics="true">
             <encoding>
@@ -284,7 +278,6 @@
                     </security>
                 </remote-store>
             </persistence>
-            <state-transfer enabled="false"/>
         </distributed-cache>
     </cache-container>
 </infinispan>


### PR DESCRIPTION
This re-enables the state transfer even if the remote store is enabled. 

There are some situations when listing user sessions for example in InfinispanUserSessionProvider where cache loaders are skipped, so all entries should be in the cache for this case. The state transfer ensures that this is the case when a node joins or leaves. 

https://github.com/keycloak/keycloak/blob/c036980c3759b833d98030cf1299297a7ec97436/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java#L396-L397

