### PR TITLE
Increase ROSA benchmark dataset timeout to factor in Aurora multi-az …

### DIFF
--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -18,7 +18,7 @@ on:
       maxWaitEntityCreation:
         description: 'Maximum number of seconds to wait for creation of entities'
         type: number
-        default: 900
+        default: 5400
       numberOfUsersPerSecond:
         description: 'User logins per second'
         type: number


### PR DESCRIPTION
The last benchmark I attempted timed out when creating the dataset. Looking at the Keycloak logs, it seems like it took ~ 75 mins to create. This PR increases the timeout to 90 mins.