### PR TITLE
Enable Gossip Router deployment in all sites

### DIFF
--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -283,8 +283,6 @@ tasks:
           CROSS_DC_LOCAL_SITE: "{{.OC_NAMESPACE_1}}"
           CROSS_DC_REMOTE_SITE: "{{.OC_NAMESPACE_2}}"
           CROSS_DC_REMOTE_SITE_NAMESPACE: "{{.OC_NAMESPACE_2}}"
-          CROSS_DC_LOCAL_GOSSIP_ROUTER: 'true'
-          CROSS_DC_REMOTE_GOSSIP_ROUTER: 'false'
       - task: deploy-infinispan
         vars:
           KUBECONFIG: "{{.ROSA_CLUSTER_NAME}}"
@@ -293,8 +291,6 @@ tasks:
           CROSS_DC_LOCAL_SITE: "{{.OC_NAMESPACE_2}}"
           CROSS_DC_REMOTE_SITE: "{{.OC_NAMESPACE_1}}"
           CROSS_DC_REMOTE_SITE_NAMESPACE: "{{.OC_NAMESPACE_1}}"
-          CROSS_DC_LOCAL_GOSSIP_ROUTER: 'false'
-          CROSS_DC_REMOTE_GOSSIP_ROUTER: 'true'
       - task: wait-cluster
         vars:
           NAMESPACE: "{{.OC_NAMESPACE_1}}"
@@ -378,8 +374,6 @@ tasks:
           CROSS_DC_LOCAL_SITE: "{{.ROSA_CLUSTER_NAME_1}}"
           CROSS_DC_REMOTE_SITE: "{{.ROSA_CLUSTER_NAME_2}}"
           CROSS_DC_API_URL: "openshift://$(cat .task/kubecfg/api-{{.ROSA_CLUSTER_NAME_2}})"
-          CROSS_DC_LOCAL_GOSSIP_ROUTER: 'true'
-          CROSS_DC_REMOTE_GOSSIP_ROUTER: 'false'
       - task: deploy-infinispan
         vars:
           ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_2}}"
@@ -390,8 +384,6 @@ tasks:
           CROSS_DC_LOCAL_SITE: "{{.ROSA_CLUSTER_NAME_2}}"
           CROSS_DC_REMOTE_SITE: "{{.ROSA_CLUSTER_NAME_1}}"
           CROSS_DC_API_URL: "openshift://$(cat .task/kubecfg/api-{{.ROSA_CLUSTER_NAME_1}})"
-          CROSS_DC_LOCAL_GOSSIP_ROUTER: 'false'
-          CROSS_DC_REMOTE_GOSSIP_ROUTER: 'true'
       - task: wait-cluster
         vars:
           ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_1}}"


### PR DESCRIPTION
This aligns the scripted deployment with the deployment outlined in the documentation prepared for users.