### PR TITLE
generate cluster name based rosa logs zip dir

### DIFF
--- a/.github/workflows/rosa-cluster-create.yml
+++ b/.github/workflows/rosa-cluster-create.yml
@@ -94,6 +94,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: rosa-logs
+          name: rosa-logs-${{ inputs.clusterName }}
           path: provision/aws/logs
           retention-days: 5


### PR DESCRIPTION
We are ending up in a race condition sometimes when the artifact upload for the `a` and `b` clusters is happening in conflict with the same directory name `rosa-logs`. This PR should aim to fix that, please review and merge if this looks like a viable option.

Below are the runs where I have seen this issue.

https://github.com/keycloak/keycloak-benchmark/actions/runs/7245204913/attempts/1
https://github.com/keycloak/keycloak-benchmark/actions/runs/7245204913/attempts/2