### PR TITLE
Allow individual/all Aurora peering connections to be removed from a …

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/storage/aurora-regional-postgres.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/storage/aurora-regional-postgres.adoc
@@ -82,15 +82,27 @@ This will create a pod in the Keycloak deployment namespace and establish a conn
 prompt will appear on initial connection and you should utilise the password defined in the Secret `keycloak-db-secret`.
 Upon exiting the pod shell, the pod will be deleted.
 
-== Disconnecting ROSA cluster from Aurora Cluster
+== Disconnecting ROSA cluster from an individual Aurora Cluster
 
-To remove a Peering Connection between the ROSA and Aurora VPCS, execute `./provision/aws/rds/aurora_delete_peering_connection.sh`
+To remove a Peering Connections between a ROSA cluster and a specific Aurora cluster, execute `./provision/aws/rds/aurora_delete_peering_connection.sh`
 with the following env:
 
 [source]
 ----
 AURORA_CLUSTER= # The name of the Aurora cluster instance
 AURORA_REGION= # The AWS region hosting the Aurora cluster
+CLUSTER_NAME= # The name of the ROSA cluster to remove the peering connection from
+AWS_REGION= # The AWS region hosting the ROSA cluster
+----
+
+== Disconnecting ROSA cluster from all Aurora Clusters
+
+To remove all Peering Connections between the ROSA and Aurora VPCS in a given region, execute `./provision/aws/rds/aurora_delete_peering_connection.sh`
+with the following env:
+
+[source]
+----
+AURORA_REGION= # The AWS region hosting the Aurora clusters
 CLUSTER_NAME= # The name of the ROSA cluster to remove the peering connection from
 AWS_REGION= # The AWS region hosting the ROSA cluster
 ----

--- a/provision/aws/rds/aurora_create_peering_connection.sh
+++ b/provision/aws/rds/aurora_create_peering_connection.sh
@@ -48,6 +48,7 @@ if [ -z "${PEERING_CONNECTION_ID}" ]; then
     --vpc-id ${ROSA_VPC} \
     --peer-vpc-id ${AURORA_VPC_ID} \
     --peer-region ${AURORA_REGION} \
+    --tag-specifications "ResourceType=vpc-peering-connection, Tags=[{Key=AuroraCluster,Value=${AURORA_CLUSTER}}]" \
     --query VpcPeeringConnection.VpcPeeringConnectionId \
     --output text
   )

--- a/provision/aws/rds/aurora_delete_peering_connection.sh
+++ b/provision/aws/rds/aurora_delete_peering_connection.sh
@@ -28,11 +28,18 @@ if [ -z "${ROSA_VPC}" ]; then
 fi
 
 # Delete all Peering connections
-PEERING_CONNECTION_IDS=$(aws ec2 describe-vpc-peering-connections \
-  --filter "Name=requester-vpc-info.vpc-id,Values=${ROSA_VPC}" "Name=status-code,Values=active"\
-  --query "VpcPeeringConnections[*].VpcPeeringConnectionId" \
-  --output text
+PEERING_CONNECTIONS=$(aws ec2 describe-vpc-peering-connections \
+  --filter "Name=requester-vpc-info.vpc-id,Values=${ROSA_VPC}" "Name=status-code,Values=active" "Name=tag-key,Values=AuroraCluster"
 )
+
+# If an Aurora cluster is not explicitly provided, remove all Aurora peering connections
+if [ -z "${AURORA_CLUSTER}" ]; then
+  AURORA_CLUSTERS=$(echo {PEERING_CONNECTIONS} | jq -r '.VpcPeeringConnections[].Tags[] | select(.Key == "AuroraCluster").Value')
+  PEERING_CONNECTION_IDS=$(echo ${PEERING_CONNECTIONS} | jq -r .VpcPeeringConnections[].VpcPeeringConnectionId)
+else
+  AURORA_CLUSTERS=${AURORA_CLUSTER}
+  PEERING_CONNECTION_IDS=$(echo ${PEERING_CONNECTIONS} | jq -r ".VpcPeeringConnections[] | select(.Tags[] | .Key == \"AuroraCluster\" and .Value == \"${AURORA_CLUSTER}\").VpcPeeringConnectionId")
+fi
 
 for PEERING_CONNECTION_ID in ${PEERING_CONNECTION_IDS}; do
   aws ec2 delete-vpc-peering-connection --vpc-peering-connection-id ${PEERING_CONNECTION_ID}
@@ -45,49 +52,51 @@ ROSA_PUBLIC_ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
   --output text
 )
 
-AURORA_VPC=$(aws ec2 describe-vpcs \
-  --filters "Name=tag:AuroraCluster,Values=${AURORA_CLUSTER}" \
-  --query 'Vpcs[0]' \
-  --output json \
-  --region ${AURORA_REGION}
-)
-AURORA_VPC_ID=$(echo ${AURORA_VPC} | jq -r .VpcId)
-AURORA_VPC_CIDR=$(echo ${AURORA_VPC} | jq -r .CidrBlock)
-
-if [ -n "${ROSA_PUBLIC_ROUTE_TABLE_ID}" ]; then
-  aws ec2 delete-route \
-    --route-table-id ${ROSA_PUBLIC_ROUTE_TABLE_ID} \
-    --destination-cidr-block ${AURORA_VPC_CIDR} || true
-fi
-
-# Cleanup Aurora Region
-# Remove the ROSA route from the Aurora cluster
-AURORA_PUBLIC_ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
-  --filters "Name=vpc-id,Values=${AURORA_VPC_ID}" "Name=association.main,Values=true" \
-  --query "RouteTables[*].RouteTableId" \
-  --region ${AURORA_REGION} \
-  --output text
-)
-
-if [ -n "${AURORA_PUBLIC_ROUTE_TABLE_ID}" ]; then
-  aws ec2 delete-route \
-    --route-table-id ${AURORA_PUBLIC_ROUTE_TABLE_ID} \
-    --destination-cidr-block ${ROSA_MACHINE_CIDR} \
-    --region ${AURORA_REGION} \
-    || true
-fi
-
-AURORA_SECURITY_GROUP_ID=$(aws ec2 describe-security-groups \
-  --filters "Name=vpc-id,Values=${AURORA_VPC_ID}" "Name=group-name,Values=${AURORA_SECURITY_GROUP_NAME}" \
-  --query "SecurityGroups[*].GroupId" \
-  --region ${AURORA_REGION} \
-  --output text
-)
-if [ -n "${AURORA_SECURITY_GROUP_ID}" ]; then
-  aws ec2 revoke-security-group-ingress \
-    --group-id ${AURORA_SECURITY_GROUP_ID} \
-    --protocol tcp \
-    --port 5432 \
-    --cidr ${ROSA_MACHINE_CIDR} \
+for AURORA_CLUSTER in ${AURORA_CLUSTERS}; do
+  AURORA_VPC=$(aws ec2 describe-vpcs \
+    --filters "Name=tag:AuroraCluster,Values=${AURORA_CLUSTER}" \
+    --query 'Vpcs[0]' \
+    --output json \
     --region ${AURORA_REGION}
-fi
+  )
+  AURORA_VPC_ID=$(echo ${AURORA_VPC} | jq -r .VpcId)
+  AURORA_VPC_CIDR=$(echo ${AURORA_VPC} | jq -r .CidrBlock)
+
+  if [ -n "${ROSA_PUBLIC_ROUTE_TABLE_ID}" ]; then
+    aws ec2 delete-route \
+      --route-table-id ${ROSA_PUBLIC_ROUTE_TABLE_ID} \
+      --destination-cidr-block ${AURORA_VPC_CIDR} || true
+  fi
+
+  # Cleanup Aurora Region
+  # Remove the ROSA route from the Aurora cluster
+  AURORA_PUBLIC_ROUTE_TABLE_ID=$(aws ec2 describe-route-tables \
+    --filters "Name=vpc-id,Values=${AURORA_VPC_ID}" "Name=association.main,Values=true" \
+    --query "RouteTables[*].RouteTableId" \
+    --region ${AURORA_REGION} \
+    --output text
+  )
+
+  if [ -n "${AURORA_PUBLIC_ROUTE_TABLE_ID}" ]; then
+    aws ec2 delete-route \
+      --route-table-id ${AURORA_PUBLIC_ROUTE_TABLE_ID} \
+      --destination-cidr-block ${ROSA_MACHINE_CIDR} \
+      --region ${AURORA_REGION} \
+      || true
+  fi
+
+  AURORA_SECURITY_GROUP_ID=$(aws ec2 describe-security-groups \
+    --filters "Name=vpc-id,Values=${AURORA_VPC_ID}" "Name=group-name,Values=${AURORA_SECURITY_GROUP_NAME}" \
+    --query "SecurityGroups[*].GroupId" \
+    --region ${AURORA_REGION} \
+    --output text
+  )
+  if [ -n "${AURORA_SECURITY_GROUP_ID}" ]; then
+    aws ec2 revoke-security-group-ingress \
+      --group-id ${AURORA_SECURITY_GROUP_ID} \
+      --protocol tcp \
+      --port 5432 \
+      --cidr ${ROSA_MACHINE_CIDR} \
+      --region ${AURORA_REGION}
+  fi
+done


### PR DESCRIPTION
I've updated the scripts so that if `AURORA_CLUSTER` is provided, then only the peering connection specific to that cluster is removed, otherwise all peering connections associated with the ROSA cluster are removed. To enable this to work, I have also added an `AuroraCluster` tag to the peering connection at creation time. I have updated the existing Aurora peering connections to also contain this tag so that on merge, things should work as expected :crossed_fingers:.