### PR TITLE
upgrade to ocp 4.14.5

### DIFF
--- a/.github/workflows/rosa-cluster-create.yml
+++ b/.github/workflows/rosa-cluster-create.yml
@@ -59,7 +59,7 @@ concurrency:
   group: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
 
 env:
-  OPENSHIFT_VERSION: 4.13.25
+  OPENSHIFT_VERSION: 4.14.5
   REGION: ${{ github.event.inputs.region || vars.AWS_DEFAULT_REGION }}
 
 jobs:


### PR DESCRIPTION
fixes #625 

This needed a pre-requisite account roles to be updated to the compatible version on the account which I documented with the parent ticket - https://github.com/keycloak/keycloak-benchmark/issues/625#issuecomment-1862121549

**create rosa cluster job:**
https://github.com/kami619/keycloak-benchmark/actions/runs/7246748671 (this run was failing due to a known issue with logging operator)
https://github.com/kami619/keycloak-benchmark/actions/runs/7257494773/job/19771394191 (this run where the logging operator was working against the `4.14.5` cluster)

**delete cluster job:**
https://github.com/kami619/keycloak-benchmark/actions/runs/7257510642