### PR TITLE
Enable JGroups Diagnostics

### DIFF
--- a/provision/infinispan/install_operator.sh
+++ b/provision/infinispan/install_operator.sh
@@ -20,4 +20,8 @@ spec:
   name: infinispan
   source: ${OPERATOR_SOURCE}
   sourceNamespace: ${OPERATOR_SOURCE_NS}
+  config:
+    env:
+      - name: JGROUPS_DIAGNOSTICS
+        value: "true"
 EOF

--- a/provision/infinispan/install_operator.sh
+++ b/provision/infinispan/install_operator.sh
@@ -23,5 +23,7 @@ spec:
   config:
     env:
       - name: JGROUPS_DIAGNOSTICS
+        # Not recommended in production since the port is not secure and allows to
+        # observe and manipulate JGroups protocols/attributes
         value: "true"
 EOF


### PR DESCRIPTION
Not recommended in production since the port is not secure and allows to observe and manipulate JGroups protocols/attributes

