### PR TITLE
Fine tune Infinispan timeouts

### DIFF
--- a/benchmark/src/main/python/snapGrafana.py
+++ b/benchmark/src/main/python/snapGrafana.py
@@ -53,7 +53,7 @@ async def generate_pdf(
 async def generate_grafana_api_token(dashboard_domain, admin_password):
     print(f"CREATE GRAFANA API KEY")
     dttm = get_current_time()
-    url =  f'http://admin:{admin_password}@{dashboard_domain}/api/auth/keys'
+    url =  f'https://admin:{admin_password}@{dashboard_domain}/api/auth/keys'
     reqBody = {'name':f'dashboard_pdf_{dttm}','role':'Editor','secondsToLive':86400}
     auth_token_id = ""
     auth_token = ""
@@ -75,7 +75,7 @@ async def generate_grafana_api_token(dashboard_domain, admin_password):
 
 async def delete_grafana_api_key(dashboard_domain, admin_password, auth_token_id):
     print(f"DELETE GRAFANA API KEY")
-    url =  f'http://admin:{admin_password}@{dashboard_domain}/api/auth/keys/{auth_token_id}'
+    url =  f'https://admin:{admin_password}@{dashboard_domain}/api/auth/keys/{auth_token_id}'
     try:
         response = requests.delete(url)
         response.raise_for_status()
@@ -97,7 +97,7 @@ async def main():
     dttm = get_current_time()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--grafana_domain", help='grafana domain without "http://" ')
+    parser.add_argument("--grafana_domain", help='grafana domain without "https://" ')
     parser.add_argument("--admin_password", help='Grafana Auth Token')
     parser.add_argument("--time_window", help='ex: from=1694700191047&to=1694700510513')
     parser.add_argument("--keycloak_namespace", help='default is runner-keycloak', default="runner-keycloak")
@@ -116,7 +116,7 @@ async def main():
         dashboard_uid = dashboard.split("/")[-1]
 
         #conditionally setting the args in the dashboard urls
-        keycloak_perf_tests_url: str =  f'http://{grafana_domain}/d/{dashboard}?orgId=1&var-namespace={keycloak_namespace}&{time_window}'
+        keycloak_perf_tests_url: str =  f'https://{grafana_domain}/d/{dashboard}?orgId=1&var-namespace={keycloak_namespace}&{time_window}'
 
         if(dashboard_uid == 'authentication-code-slo' or dashboard_uid == 'client-credentials-slo'):
             keycloak_perf_tests_url = keycloak_perf_tests_url+f'&var-pod_name=All'

--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -85,7 +85,7 @@ tasks:
         --set replicas={{.CROSS_DC_ISPN_REPLICAS}}
         --set cpu={{.CROSS_DC_CPU_REQUESTS}}
         --set memory={{.CROSS_DC_MEMORY_REQUESTS}}
-        --set jvmOptions={{.CROSS_DC_JVM_OPTS}}
+        --set jvmOptions={{.CROSS_DC_JVM_OPTS | quote}}
         --set crossdc.enabled={{.CROSS_DC_ENABLED}}
         --set crossdc.local.name={{.CROSS_DC_LOCAL_SITE}}
         --set crossdc.local.gossipRouterEnabled={{.CROSS_DC_LOCAL_GOSSIP_ROUTER}}

--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -85,6 +85,9 @@ spec:
         # end::infinispan-crossdc[]
         discovery:
           launchGossipRouter: {{ .Values.crossdc.local.gossipRouterEnabled }}
+          heartbeats:
+            interval: {{ .Values.crossdc.heartbeats.interval }}
+            timeout: {{ .Values.crossdc.heartbeats.timeout }}
         # tag::infinispan-crossdc[]
         expose:
           type: {{ if .Values.crossdc.route.enabled }}Route{{else}}ClusterIP{{end}} # <5>
@@ -135,6 +138,7 @@ spec:
       mode: "SYNC"
       owners: {{ $config.owners | default $.Values.cacheDefaults.owners | quote }}
       statistics: "true"
+      remoteTimeout: {{ $config.remoteTimeout | default $.Values.cacheDefaults.remoteTimeout }}
       stateTransfer:
         chunkSize: 16
       {{ if $.Values.crossdc.enabled }}
@@ -146,6 +150,7 @@ spec:
         {{$.Values.crossdc.remote.name }}: # <2>
           backup:
             strategy: {{ $config.crossSiteMode | default $.Values.cacheDefaults.crossSiteMode | quote }} # <3>
+            timeout: {{ $config.xsiteRemoteTimeout | default $.Values.cacheDefaults.xsiteRemoteTimeout }}
             stateTransfer:
               chunkSize: 16
               {{- if eq ($config.crossSiteMode | default $.Values.cacheDefaults.crossSiteMode) "ASYNC"}}

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -10,6 +10,8 @@ cacheDefaults:
   crossSiteMode: SYNC
   # AUTO or MANUAL
   stateTransferMode: AUTO
+  remoteTimeout: 14000
+  xsiteRemoteTimeout: 13000
 caches:
   sessions:
     owners: 2
@@ -39,6 +41,9 @@ crossdc:
         filename: keystore.p12
       truststore:
         filename: truststore.p12
+  heartbeats:
+    interval: 2000
+    timeout: 8000
 logging:
   infinispan: info
   jgroups: info
@@ -47,4 +52,4 @@ metrics:
   histograms: false
 fd:
   interval: 2000
-  timeout: 10000
+  timeout: 15000


### PR DESCRIPTION
Fine tunning timeouts in Infinispan and JGroups

* Tunnel Heartbeats timeout must be lower than Infinispan cross-site timeout to allow the offline gossip router to be detected and retransmissions to be forwarded to the online gossip router without timing out the write operation at Infinispan
* Failure detection timeout must be higher than Tunnel heartbeat timeout to prevent a node from being suspected in case a gossip router is down
* Reduce timeout in Infinispan server to prevent Keycloak timeouts; although, I'm not sure if it is a good idea or not at this point. 

Edit: fixed the grafana snapshot python script to use HTTPS instead of HTTP.