### PR TITLE
Use JGroups MTLS setup with certmanager generated certificates

### DIFF
--- a/provision/minikube/keycloak/templates/certmanager/certmanager-jgroups-tls.yaml
+++ b/provision/minikube/keycloak/templates/certmanager/certmanager-jgroups-tls.yaml
@@ -1,0 +1,38 @@
+{{ if .Values.infinispan.jgroupsTls }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: {{ .Values.namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-jgroups-pkcs12-password
+  namespace: {{ .Values.namespace }}
+data:
+  password: a2V5Y2xvYWs= # keycloak
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-jgroups-selfsigned
+  namespace: {{ .Values.namespace }}
+spec:
+  # This certificate will be valid for 90 days by default, with a renewal after 60 days.
+  # In a production environment, consider using a longer duration, as after each renewal, the Keycloak pods would need to be restarted
+  commonName: keycloak-jgroups
+  secretName: keycloak-jgroups
+  keystores:
+    pkcs12:
+      create: true
+      passwordSecretRef: # Password used to encrypt the keystore
+        key: password
+        name: keycloak-jgroups-pkcs12-password
+  issuerRef:
+    name: selfsigned
+    kind: Issuer
+    group: cert-manager.io
+{{ end }}

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -93,6 +93,22 @@ spec:
         key: password
     # end::keycloak-ispn[]
 {{- end }}
+{{- if .Values.infinispan.jgroupsTls }}
+    - name: cache-embedded-mtls-enabled
+      value: "true"
+    - name: cache-embedded-mtls-key-store-file
+      value: /etc/cache-embedded-mtls/keystore.p12
+    - name: cache-embedded-mtls-key-store-password
+      secret:
+        name: keycloak-jgroups-pkcs12-password
+        key: password
+    - name: cache-embedded-mtls-trust-store-file
+      value: /etc/cache-embedded-mtls/truststore.p12
+    - name: cache-embedded-mtls-trust-store-password
+      secret:
+        name: keycloak-jgroups-pkcs12-password
+        key: password
+{{- end }}
   http:
     tlsSecret: keycloak-tls-secret
   instances: {{ .Values.instances }}
@@ -248,6 +264,11 @@ spec:
               - name: keycloak-providers
                 mountPath: /opt/keycloak/providers
                 readOnly: true
+{{ if .Values.infinispan.jgroupsTls }}
+              - name: cache-embedded-mtls-volume
+                mountPath: /etc/cache-embedded-mtls
+                readOnly: true
+{{ end }}
 {{ if .Values.otel }}
               - name: otel
                 mountPath: /otel
@@ -271,4 +292,9 @@ spec:
           - name: otel
             persistentVolumeClaim:
               claimName: otel
+{{ end }}
+{{ if .Values.infinispan.jgroupsTls }}
+          - name: cache-embedded-mtls-volume
+            secret:
+              secretName: keycloak-jgroups
 {{ end }}

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -39,6 +39,7 @@ disableIngressStickySession: false
 jvmDebug: true
 predefinedAdmin: true
 infinispan:
+  jgroupsTls: false
   customConfig: false
   # file must be in "config/" directory
   configFile: config/kcb-infinispan-cache-config.xml

--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -6,6 +6,7 @@ vars:
   KC_HOSTNAME_SUFFIX: '{{default "$(kubectl get route/console -n openshift-console -o jsonpath=\u0027{.spec.host}\u0027 | cut -d . -f 2-)" .KC_HOSTNAME_SUFFIX}}'
   KC_NAMESPACE_PREFIX: '{{default "$(whoami)-" .KC_NAMESPACE_PREFIX}}'
   KC_ADMIN_PASSWORD: '{{default "$(aws secretsmanager get-secret-value --region eu-central-1 --secret-id keycloak-master-password --query SecretString --output text --no-cli-pager || echo admin)" .KC_ADMIN_PASSWORD}}'
+  KC_JGROUPS_TLS: '{{default "true" .KC_JGROUPS_TLS}}'
 
 output: prefixed
 
@@ -251,6 +252,7 @@ tasks:
         --set heapMaxMB={{ .KC_HEAP_MAX_MB }}
         --set metaspaceInitMB={{ .KC_METASPACE_INIT_MB }}
         --set metaspaceMaxMB={{ .KC_METASPACE_MAX_MB }}
+        --set infinispan.jgroupsTls={{ .KC_JGROUPS_TLS }}
         --set infinispan.customConfig={{ .KC_CUSTOM_INFINISPAN_CONFIG }}
         --set infinispan.configFile={{ .KC_CUSTOM_INFINISPAN_CONFIG_FILE }}
         --set infinispan.remoteStore.enabled=$(cat .task/remote-store-enabled)

--- a/provision/rosa-cross-dc/Taskfile.yaml
+++ b/provision/rosa-cross-dc/Taskfile.yaml
@@ -17,6 +17,7 @@ vars:
   BENCHMARK_DIR: "{{.ROOT_DIR}}/../../benchmark/src/main/content/bin"
   KEYCLOAK_MASTER_PASSWORD:
     sh: aws secretsmanager get-secret-value --region eu-central-1 --secret-id keycloak-master-password --query SecretString --output text --no-cli-pager
+  KC_JGROUPS_TLS: '{{default "true" .KC_JGROUPS_TLS}}'
 
 dotenv: [ '.env' ]
 
@@ -276,6 +277,7 @@ tasks:
         --set heapMaxMB={{ .KC_HEAP_MAX_MB }}
         --set metaspaceInitMB={{ .KC_METASPACE_INIT_MB }}
         --set metaspaceMaxMB={{ .KC_METASPACE_MAX_MB }}
+        --set infinispan.jgroupsTls={{ .KC_JGROUPS_TLS }}
         --set infinispan.customConfig={{ .KC_CUSTOM_INFINISPAN_CONFIG }}
         --set infinispan.configFile={{ .KC_CUSTOM_INFINISPAN_CONFIG_FILE }}
         --set infinispan.remoteStore.enabled=true


### PR DESCRIPTION
Related to: keycloak/keycloak#25703

Until the PR listed above is merged and the code is available in a nightly build, a locally built image will need to be used.