### PR TITLE
Use `http-pool-max-threads` instead of `QUARKUS_THREAD_POOL_MAX_THREADS`

### DIFF
--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -67,7 +67,7 @@ spec:
     - name: storage-hotrod-password
       value: admin
 {{ end }}
-{{ if .Values.disableCaches }}
+{{- if .Values.disableCaches }}
     - name: cache-realm-enabled
       value: 'false'
     - name: cache-user-enabled
@@ -85,6 +85,8 @@ spec:
       value: json
     - name: metrics-enabled # <3>
       value: 'true'
+    - name: http-pool-max-threads # <4>
+      value: {{ div 200 .Values.instances | quote }}
 {{- if .Values.infinispan.remoteStore.enabled }}
     # tag::keycloak-ispn[]
     - name: remote-store-host # <2>
@@ -155,8 +157,6 @@ spec:
             imagePullPolicy: Never
 {{ end }}
             env:
-              - name: 'QUARKUS_THREAD_POOL_MAX_THREADS' # <4>
-                value: {{ div 200 .Values.instances | quote }}
               # end::keycloak[]
               # We want to have an externally provided username and password, therefore, we override those two environment variables
               - name: KEYCLOAK_ADMIN


### PR DESCRIPTION
As per the recent changes in Keycloak https://github.com/keycloak/keycloak/issues/26455 we need to consume the same in the keycloak-benchmark deployments.