### PR TITLE
Add possibility to configure AWS JDBC Wrapper for Keycloak driver

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/openshift/cross-site-rosa.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/openshift/cross-site-rosa.adoc
@@ -92,3 +92,10 @@ Note: SSH repositories may not work in Github Actions as SSH keys may not be con
 
 |===
 
+=== Using AWS JDBC driver
+
+AWS provides a https://github.com/awslabs/aws-advanced-jdbc-wrapper[JDBC driver wrapper] that is compatible with Aurora PostgreSQL we are using in our setup. This driver provides some additional features when using compatible databases. This wrapper is enabled by default in the Cross-site deployment.
+
+To disable the AWS JDBC driver, set the `KC_USE_AWS_JDBC_WRAPPER` variable to `false`.
+
+To specify the version of the AWS JDBC driver, set the `KC_AWS_JDBC_WRAPPER_URL` variable to the URL of corresponding jar file.

--- a/provision/keycloak-tasks/Taskfile.yaml
+++ b/provision/keycloak-tasks/Taskfile.yaml
@@ -57,3 +57,6 @@ tasks:
   default:
     cmds:
       - task: utils:install-keycloak
+  uninstall:
+    cmds:
+      - task: utils:uninstall-keycloak

--- a/provision/keycloak-tasks/Utils.yaml
+++ b/provision/keycloak-tasks/Utils.yaml
@@ -201,6 +201,7 @@ tasks:
         vars:
           NAMESPACE: "{{.NAMESPACE}}"
           KUBECONFIG: "{{.KUBECONFIG}}"
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME}}"
       - task: install-keycloak-operator
         vars:
           NAMESPACE: "{{.NAMESPACE}}"

--- a/provision/keycloak-tasks/Utils.yaml
+++ b/provision/keycloak-tasks/Utils.yaml
@@ -54,8 +54,8 @@ tasks:
       - KUBECONFIG="{{.KUBECONFIG}}" oc create namespace "{{.NAMESPACE}}" || true
       - >
         KUBECONFIG="{{.KUBECONFIG}}" helm upgrade --install keycloak-build-config --namespace "{{.NAMESPACE}}" ./keycloak-image-helm
-        --set "namespace={{.NAMESPACE}}"
-        --set "customImage={{if .KC_REPOSITORY}}true{{else}}false{{end}}"
+        --set namespace={{.NAMESPACE}}
+        --set customImage={{if .KC_REPOSITORY}}true{{else}}false{{end}}
     status:
       - test -n "$(KUBECONFIG="{{.KUBECONFIG}}" helm list --namespace {{.NAMESPACE}} --filter keycloak-build-config -q)"
     preconditions:
@@ -76,17 +76,8 @@ tasks:
       ARCHIVE_NAME:
         sh: ls .task/keycloak/quarkus/dist/target/keycloak-*.tar.gz | xargs -n 1 basename
     cmds:
-      - KUBECONFIG="{{.KUBECONFIG}}" oc create namespace "{{.NAMESPACE}}" || true
-      - KUBECONFIG={{.KUBECONFIG}} helm uninstall --namespace {{.NAMESPACE}} keycloak-build-config || true
-      # Create custom Keycloak resources for both Keycloak and Keycloak operator
-      - >
-        KUBECONFIG="{{.KUBECONFIG}}" helm upgrade --install keycloak-build-config --namespace "{{.NAMESPACE}}"
-        --set "namespace={{.NAMESPACE}}"
-        --set "archiveName={{.ARCHIVE_NAME}}"
-        ./keycloak-image-helm
-
       # Start Keycloak image build
-      - cp "$(ls .task/keycloak/quarkus/dist/target/keycloak-*.tar.gz)" ".task/keycloak/quarkus/container/"
+      - cp "$(ls .task/keycloak/quarkus/dist/target/keycloak-*.tar.gz)" ".task/keycloak/quarkus/container/keycloak.tar.gz"
       - KUBECONFIG="{{.KUBECONFIG}}" oc start-build -n {{.NAMESPACE}} keycloak --from-dir ".task/keycloak/quarkus/container" --follow
       - echo "image-registry.openshift-image-registry.svc:5000/{{.NAMESPACE}}/keycloak:latest" > .task/var-CUSTOM_CONTAINER_IMAGE_FILE
 

--- a/provision/keycloak-tasks/Utils.yaml
+++ b/provision/keycloak-tasks/Utils.yaml
@@ -56,6 +56,8 @@ tasks:
         KUBECONFIG="{{.KUBECONFIG}}" helm upgrade --install keycloak-build-config --namespace "{{.NAMESPACE}}" ./keycloak-image-helm
         --set namespace={{.NAMESPACE}}
         --set customImage={{if .KC_REPOSITORY}}true{{else}}false{{end}}
+        {{ if eq .KC_USE_AWS_JDBC_WRAPPER "false"}}--set useAWSJDBCWrapper={{.KC_USE_AWS_JDBC_WRAPPER}}{{end}}
+        --set jdbcWrapperURL={{.KC_AWS_JDBC_WRAPPER_URL}}
     status:
       - test -n "$(KUBECONFIG="{{.KUBECONFIG}}" helm list --namespace {{.NAMESPACE}} --filter keycloak-build-config -q)"
     preconditions:
@@ -188,7 +190,7 @@ tasks:
           KUBECONFIG: "{{.KUBECONFIG}}"
           NAMESPACE: "{{.NAMESPACE}}"
           ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME}}"
-      - task: '{{if .KC_USE_AWS_JDBC_WRAPPER}}prepare-keycloak-image-with-aws-jdbc-wrapper-openshift{{else}}no-op{{end}}'
+      - task: '{{if eq .KC_USE_AWS_JDBC_WRAPPER "true"}}prepare-keycloak-image-with-aws-jdbc-wrapper-openshift{{else}}no-op{{end}}'
         vars:
           NAMESPACE: "{{.NAMESPACE}}"
           KUBECONFIG: "{{.KUBECONFIG}}"

--- a/provision/keycloak-tasks/Utils.yaml
+++ b/provision/keycloak-tasks/Utils.yaml
@@ -57,7 +57,7 @@ tasks:
         --set namespace={{.NAMESPACE}}
         --set customImage={{if .KC_REPOSITORY}}true{{else}}false{{end}}
         {{ if eq .KC_USE_AWS_JDBC_WRAPPER "false"}}--set useAWSJDBCWrapper={{.KC_USE_AWS_JDBC_WRAPPER}}{{end}}
-        --set jdbcWrapperURL={{.KC_AWS_JDBC_WRAPPER_URL}}
+        {{ if .KC_AWS_JDBC_WRAPPER_URL}}--set jdbcWrapperURL={{.KC_AWS_JDBC_WRAPPER_URL}}{{end}}
     status:
       - test -n "$(KUBECONFIG="{{.KUBECONFIG}}" helm list --namespace {{.NAMESPACE}} --filter keycloak-build-config -q)"
     preconditions:

--- a/provision/keycloak-tasks/Utils.yaml
+++ b/provision/keycloak-tasks/Utils.yaml
@@ -43,6 +43,24 @@ tasks:
       - quarkus/dist/target/keycloak-*.tar.gz
       - operator/target/keycloak-*.jar
 
+  install-keycloak-build-configs:
+    desc: "Install the Keycloak build configs"
+    internal: true
+    requires:
+      vars:
+        - NAMESPACE
+        - KUBECONFIG
+    cmds:
+      - KUBECONFIG="{{.KUBECONFIG}}" oc create namespace "{{.NAMESPACE}}" || true
+      - >
+        KUBECONFIG="{{.KUBECONFIG}}" helm upgrade --install keycloak-build-config --namespace "{{.NAMESPACE}}" ./keycloak-image-helm
+        --set "namespace={{.NAMESPACE}}"
+        --set "customImage={{if .KC_REPOSITORY}}true{{else}}false{{end}}"
+    status:
+      - test -n "$(KUBECONFIG="{{.KUBECONFIG}}" helm list --namespace {{.NAMESPACE}} --filter keycloak-build-config -q)"
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+
   prepare-keycloak-images-openshift:
     desc: "Create images for the current build of Keycloak distribution"
     label: "{{.TASK}}-{{.ROSA_CLUSTER_NAME}}"
@@ -78,10 +96,22 @@ tasks:
     sources:
       - quarkus/dist/target/keycloak-*.tar.gz
       - operator/target/keycloak-*.jar
-    status:
-      - test -n "$(KUBECONFIG="{{.KUBECONFIG}}" helm list --namespace {{.NAMESPACE}} --filter keycloak-build-config -q)"
     preconditions:
       - test -f {{.KUBECONFIG}}
+
+  prepare-keycloak-image-with-aws-jdbc-wrapper-openshift:
+    desc: "Create images for the current build of Keycloak distribution"
+    label: "{{.TASK}}-{{.ROSA_CLUSTER_NAME}}"
+    internal: true
+    requires:
+      vars:
+        - NAMESPACE
+        - KUBECONFIG
+        - ROSA_CLUSTER_NAME
+    cmds:
+      # Creates .task if it does not exist
+      - if [ ! -d .task ]; then mkdir .task; fi
+      - echo "image-registry.openshift-image-registry.svc:5000/{{.NAMESPACE}}/keycloak-with-aws-jdbc-wrapper:latest" > .task/var-CUSTOM_CONTAINER_IMAGE_FILE
 
   install-keycloak-operator:
     desc: "Install the Keycloak operator"
@@ -156,12 +186,21 @@ tasks:
         - ROSA_CLUSTER_NAME
     vars:
       CURRENT_KC_CONTAINER_IMAGE: '{{ ternary "$(cat .task/var-CUSTOM_CONTAINER_IMAGE_FILE 2> /dev/null || echo \"\")" .KC_CONTAINER_IMAGE (empty .KC_CONTAINER_IMAGE) }}'
+      KC_USE_AWS_JDBC_WRAPPER: '{{ .KC_USE_AWS_JDBC_WRAPPER | default "true" }}'
     cmds:
+      - task: install-keycloak-build-configs
+        vars:
+          NAMESPACE: "{{.NAMESPACE}}"
+          KUBECONFIG: "{{.KUBECONFIG}}"
       - task: '{{if .KC_REPOSITORY}}prepare-custom-images{{else}}no-op{{end}}'
         vars:
           KUBECONFIG: "{{.KUBECONFIG}}"
           NAMESPACE: "{{.NAMESPACE}}"
           ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME}}"
+      - task: '{{if .KC_USE_AWS_JDBC_WRAPPER}}prepare-keycloak-image-with-aws-jdbc-wrapper-openshift{{else}}no-op{{end}}'
+        vars:
+          NAMESPACE: "{{.NAMESPACE}}"
+          KUBECONFIG: "{{.KUBECONFIG}}"
       - task: install-keycloak-operator
         vars:
           NAMESPACE: "{{.NAMESPACE}}"

--- a/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-build-config.yaml
+++ b/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-build-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customImage }}
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
@@ -34,3 +35,4 @@ spec:
         kind: ImageStreamTag
         name: ubi9:latest
     type: Docker
+{{ end }}

--- a/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-nightly-imagestream.yaml
+++ b/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-nightly-imagestream.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.customImage }}
+{{- if and (.Values.useAWSJDBCWrapper) (not .Values.customImage) }}
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
-  name: ubi9
+  name: keycloak
   namespace: {{ .Values.namespace }}
 spec:
   lookupPolicy:
@@ -11,7 +11,7 @@ spec:
     - name: latest
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/ubi9
+        name: quay.io/keycloak/keycloak:nightly
       generation: 2
       importPolicy:
         importMode: Legacy

--- a/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-operator-build-config.yaml
+++ b/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-operator-build-config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.customImage }}
 kind: ImageStream
 apiVersion: image.openshift.io/v1
 metadata:
@@ -31,3 +32,4 @@ spec:
         kind: ImageStreamTag
         name: ubi9:latest
     type: Docker
+  {{ end }}

--- a/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-with-AWS-JDBC-wrapper.yaml
+++ b/provision/keycloak-tasks/keycloak-image-helm/templates/keycloak-with-AWS-JDBC-wrapper.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.useAWSJDBCWrapper }}
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: keycloak-with-aws-jdbc-wrapper
+  namespace: {{ .Values.namespace }}
+  labels:
+    build: keycloak
+spec:
+  lookupPolicy:
+    local: false
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    build: keycloak
+  name: keycloak-with-aws-jdbc-wrapper
+  namespace: {{ .Values.namespace }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: keycloak-with-aws-jdbc-wrapper:latest
+  runPolicy: Serial
+  triggers:
+    - type: "ImageChange"
+      imageChange:
+        from:
+          kind: "ImageStreamTag"
+          name: "keycloak:latest"
+  strategy:
+    dockerStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "keycloak:latest"
+      forcePull: true
+  source:
+    dockerfile: |
+      FROM keycloak:latest
+      ADD --chmod=0666 {{ .Values.jdbcWrapperURL }} /opt/keycloak/providers/
+      ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
+{{ end }}

--- a/provision/keycloak-tasks/keycloak-image-helm/values.yaml
+++ b/provision/keycloak-tasks/keycloak-image-helm/values.yaml
@@ -3,3 +3,6 @@
 # Declare variables to be passed into your templates.
 
 namespace: keycloak
+customImage: false
+useAWSJDBCWrapper: true
+jdbcWrapperURL: https://github.com/awslabs/aws-advanced-jdbc-wrapper/releases/download/2.3.3/aws-advanced-jdbc-wrapper-2.3.3.jar

--- a/provision/minikube/keycloak/templates/aurora/aurora-service.yaml
+++ b/provision/minikube/keycloak/templates/aurora/aurora-service.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.database "aurora-postgres" }}
+{{ if and (eq .Values.database "aurora-postgres") (not .Values.useAWSJDBCWrapper) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -27,7 +27,7 @@ spec:
 {{ if or (eq .Values.database "aurora-postgres") (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
     vendor: postgres
 {{- if .Values.useAWSJDBCWrapper}}
-    url: jdbc:aws-wrapper:postgresql://postgres:5432/keycloak
+    url: jdbc:aws-wrapper:postgresql://{{ .Values.dbUrl }}:5432/keycloak
 {{- else }}
     url: jdbc:postgresql://postgres:5432/keycloak
 {{ end }}

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -65,6 +65,10 @@ spec:
         key: {{ base .Values.infinispan.configFile }} # <1>
   # end::keycloak-ispn[]
 {{- end }}
+{{ if .Values.useAWSJDBCWrapper }}
+  transaction:
+    xaEnabled: false
+{{ end }}
   # tag::keycloak-ispn[]
   additionalOptions:
   # end::keycloak-ispn[]
@@ -137,8 +141,6 @@ spec:
 {{ if .Values.useAWSJDBCWrapper }}
     - name: db-driver
       value: software.amazon.jdbc.Driver
-    - name: transaction-xa-enabled
-      value: 'false'
 {{ end }}
   http:
     tlsSecret: keycloak-tls-secret
@@ -253,9 +255,13 @@ spec:
             #     command:
             #       - 'true'
             volumeMounts:
+              {{- range $path, $size := .Files.Glob "providers/**" }}
+              {{- $name := base $path }}
               - name: keycloak-providers
-                mountPath: /opt/keycloak/providers/mounted-providers
+                mountPath: /opt/keycloak/providers/{{ $name }}
+                subPath: {{ $name }}
                 readOnly: true
+              {{- end -}}
 {{ if .Values.infinispan.jgroupsTls }}
               - name: cache-embedded-mtls-volume
                 mountPath: /etc/cache-embedded-mtls

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -26,7 +26,11 @@ spec:
   db:
 {{ if or (eq .Values.database "aurora-postgres") (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan") }}
     vendor: postgres
+{{- if .Values.useAWSJDBCWrapper}}
+    url: jdbc:aws-wrapper:postgresql://postgres:5432/keycloak
+{{- else }}
     url: jdbc:postgresql://postgres:5432/keycloak
+{{ end }}
 {{ end }}
     poolMinSize: {{ .Values.dbPoolMinSize }} # <1>
     poolInitialSize: {{ .Values.dbPoolInitialSize }}
@@ -130,6 +134,12 @@ spec:
         name: keycloak-jgroups-pkcs12-password
         key: password
 {{- end }}
+{{ if .Values.useAWSJDBCWrapper }}
+    - name: db-driver
+      value: software.amazon.jdbc.Driver
+    - name: transaction-xa-enabled
+      value: 'false'
+{{ end }}
   http:
     tlsSecret: keycloak-tls-secret
   instances: {{ .Values.instances }}
@@ -244,7 +254,7 @@ spec:
             #       - 'true'
             volumeMounts:
               - name: keycloak-providers
-                mountPath: /opt/keycloak/providers
+                mountPath: /opt/keycloak/providers/mounted-providers
                 readOnly: true
 {{ if .Values.infinispan.jgroupsTls }}
               - name: cache-embedded-mtls-volume

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -18,6 +18,7 @@ dbPoolInitialSize: 15
 dbPoolMaxSize: 15
 dbPoolMinSize: 15
 dbUrl: ''
+useAWSJDBCWrapper: true
 storage: ''
 database: postgres
 disableCaches: false

--- a/provision/rosa-cross-dc/Taskfile.yaml
+++ b/provision/rosa-cross-dc/Taskfile.yaml
@@ -601,6 +601,17 @@ tasks:
       - >
         echo 'WARNING: use the information above to configure your Keycloak deployment!'
 
+  route53-test-primary-used:
+    desc: "Checks if the primary cluster is active and prints it to the console"
+    dir: "{{.ROUTE53_DIR}}"
+    deps:
+      - common:split
+      - common:env
+    requires:
+      vars:
+        - KC_CLIENT_URL
+    cmd: (./route53_test_primary_used.sh {{substr 7 999999 .KC_CLIENT_URL}} && echo "Primary cluster is active") || echo "Primary cluster is NOT active"
+
   dataset-import:
     internal: true
     requires:


### PR DESCRIPTION
Closes #698

This is WIP PR to use the AWS JDBC wrapper for. 

Checklist:
- [x]  Build image containing AWS JDBC wrapper jar
- [x] Test in CrossDC environment (I tested only in single OCP with ephemeral postgres and checked the logs)
- [x] Test with custom image build
- [x] Sort out the conflict between the image containing jar files in `/keycloak/providers` and mounting within helm chart (two options: make Keycloak look for jar files recursively (suggested by @ryanemerson in issue) or add all jar files when building image). I prefer 1st but it requires a change in Keycloak
- [x] Document new options
- [x] Optional: test database failover does not break Keycloak connections

I am testing this from `keycloak-tasks` directory with the following `.env` file:
```
KC_INSTANCES=1
KC_HOSTNAME_SUFFIX=<cluster-hostname-suffix>

ROSA_CLUSTER_NAME=gh-keycloak-a
KUBECONFIG=/path/to/kubeconfig
NAMESPACE=mhajas-keycloak

```