### PR TITLE
first steps on upgrading gatling to the latest

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -7,12 +7,12 @@
     <version>0.12-SNAPSHOT</version>
 
     <properties>
-        <scala.version>2.12.10</scala.version>
-        <gatling.version>3.4.2</gatling.version>
+        <scala.version>2.13.13</scala.version>
+        <gatling.version>3.10.4</gatling.version>
         <janino.version>3.1.7</janino.version>
-        <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <encoding>UTF-8</encoding>
     </properties>
 
@@ -72,7 +72,7 @@
                         </goals>
                         <configuration>
                             <args>
-                                <arg>-target:jvm-1.8</arg>
+                                <arg>-target:jvm-17</arg>
                                 <arg>-deprecation</arg>
                                 <arg>-feature</arg>
                                 <arg>-unchecked</arg>
@@ -113,8 +113,8 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>io.gatling:gatling-recorder:*</exclude>
-                                    <exclude>org.scala-lang.modules:scala-swing_2.12:*</exclude>
-                                    <exclude>org.scala-lang.modules:scala-java8-compat_2.12:*</exclude>
+                                    <exclude>org.scala-lang.modules:scala-swing_2.13:*</exclude>
+                                    <exclude>org.scala-lang.modules:scala-java8-compat_2.13:*</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>

--- a/benchmark/src/main/scala/IDEPathHelper.scala
+++ b/benchmark/src/main/scala/IDEPathHelper.scala
@@ -1,5 +1,5 @@
 
-import io.gatling.commons.util.PathHelper.RichPath
+import io.gatling.shared.util.PathHelper.RichPath
 
 import java.nio.file.{Path, Paths}
 


### PR DESCRIPTION
I started off taking the leap of faith by pushing the gatling to the latest version, as the earlier versions and scala dependencies have some CVE's listed.

I was able to fix one library refactoring, but now stuck with an issue around `java.nio.file.Path`'s `ancestor` method being phased out to fetch the root directory of the project, modifying that to `getRoot()` was returning more downstream issues. Would love to tag team with someone on this.

```
[INFO] --- scala-maven-plugin:4.8.1:compile (compile) @ keycloak-benchmark ---
[INFO] Compiler bridge file: /Users/kameswararaoakella/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.13-1.8.0-bin_2.13.13__61.0-1.8.0_20221110T195421.jar
[INFO] compiling 29 Scala sources and 6 Java sources to /Users/kameswararaoakella/code/redhat/keycloak-benchmark/benchmark/target/classes ...
[WARNING] : -target is deprecated: Use -release instead to compile against the correct platform API.
[ERROR] /Users/kameswararaoakella/code/redhat/keycloak-benchmark/benchmark/src/main/scala/IDEPathHelper.scala:9: value ancestor is not a member of java.nio.file.Path
[WARNING] /Users/kameswararaoakella/code/redhat/keycloak-benchmark/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala:291: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method logout,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
[WARNING] /Users/kameswararaoakella/code/redhat/keycloak-benchmark/benchmark/src/main/scala/keycloak/scenario/KeycloakScenarioBuilder.scala:310: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method logout,
or remove the empty argument list from its definition (Java-defined methods are exempt).
In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
[WARNING] three warnings found
[ERROR] one error found

```