### PR TITLE
Added transactional caches to external Infinispan

### DIFF
--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -97,10 +97,16 @@ tasks:
         --set crossdc.route.enabled={{.CROSS_DC_EXTERNAL_ROUTER_ENABLED}}
         --set crossdc.route.tls.keystore.secret={{.CROSS_DC_JGRP_KS_SECRET}}
         --set crossdc.route.tls.truststore.secret={{.CROSS_DC_JGRP_TS_SECRET}}
+        --set crossdc.maxRelayNodes={{if eq .CROSS_DC_TX_2PC "true" }}1{{else}}128{{end}}
         --set metrics.histograms={{.CROSS_DC_HISTOGRAMS}}
         --set hotrodPassword={{.CROSS_DC_HOT_ROD_PASSWORD}}
         --set cacheDefaults.crossSiteMode={{.CROSS_DC_MODE}}
         --set cacheDefaults.stateTransferMode={{.CROSS_DC_STATE_TRANSFER_MODE}}
+        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "WARN" }}
+        --set cacheDefaults.txMode={{if eq .CROSS_DC_TX_2PC "true" }}NON_XA{{else}}NONE{{end}}
+        --set cacheDefaults.xsiteTwoPhaseCommit={{.CROSS_DC_TX_2PC | default "false" }}
+        --set cacheDefaults.xsiteOfflineMinWait={{.CROSS_DC_OFFLINE_MIN_WAIT | default "30000" }}
+        --set cacheDefaults.xsiteOfflineAfterFailures={{.CROSS_DC_OFFLINE_AFTER_FAILURES | default "-1" }}
         --set image={{.CROSS_DC_IMAGE}}
         --set fd.interval={{.CROSS_DC_FD_INTERVAL}}
         --set fd.timeout={{.CROSS_DC_FD_TIMEOUT}}

--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -91,7 +91,7 @@ spec:
         # tag::infinispan-crossdc[]
         expose:
           type: {{ if .Values.crossdc.route.enabled }}Route{{else}}ClusterIP{{end}} # <5>
-        maxRelayNodes: 128
+        maxRelayNodes: {{ .Values.crossdc.maxRelayNodes }}
         {{ if .Values.crossdc.route.enabled }}
         {{- $_ := .Values.crossdc.route.tls.keystore.secret | required ".Values.crossdc.route.tls.keystore.secret is required." -}}
         {{- $_ := .Values.crossdc.route.tls.truststore.secret | required ".Values.crossdc.route.tls.truststore.secret is required." -}}
@@ -138,26 +138,34 @@ spec:
       mode: "SYNC"
       owners: {{ $config.owners | default $.Values.cacheDefaults.owners | quote }}
       statistics: "true"
-      remoteTimeout: {{ $config.remoteTimeout | default $.Values.cacheDefaults.remoteTimeout }}
+      remoteTimeout: {{ $config.remoteTimeout | default $.Values.cacheDefaults.remoteTimeout | quote }}
       locking:
-        acquireTimeout: {{ $config.lockTimeout | default $.Values.cacheDefaults.lockTimeout }}
+        acquireTimeout: {{ $config.lockTimeout | default $.Values.cacheDefaults.lockTimeout | quote }}
+      transaction:
+        mode: {{ $config.txMode | default $.Values.cacheDefaults.txMode | quote }}
+        locking: {{ $config.txLockMode | default $.Values.cacheDefaults.txLockMode | quote }}
       stateTransfer:
-        chunkSize: 16
+        chunkSize: "16"
       {{ if $.Values.crossdc.enabled }}
       {{- $_ := $.Values.crossdc.remote.name | required ".Values.crossdc.remote.name is required." -}}
       backups:
         {{- if $config.mergePolicy }}
-        mergePolicy: {{ $config.mergePolicy }} # <1>
+        mergePolicy: {{ $config.mergePolicy  | quote }} # <1>
         {{- end}}
         {{$.Values.crossdc.remote.name }}: # <2>
           backup:
             strategy: {{ $config.crossSiteMode | default $.Values.cacheDefaults.crossSiteMode | quote }} # <3>
-            timeout: {{ $config.xsiteRemoteTimeout | default $.Values.cacheDefaults.xsiteRemoteTimeout }}
+            timeout: {{ $config.xsiteRemoteTimeout | default $.Values.cacheDefaults.xsiteRemoteTimeout | quote }}
+            failurePolicy: {{ $config.xsiteFailurePolicy | default $.Values.cacheDefaults.xsiteFailurePolicy | quote }}
+            twoPhaseCommit: {{ $config.xsiteTwoPhaseCommit | default $.Values.cacheDefaults.xsiteTwoPhaseCommit | quote }}
             stateTransfer:
-              chunkSize: 16
+              chunkSize: "16"
               {{- if eq ($config.crossSiteMode | default $.Values.cacheDefaults.crossSiteMode) "ASYNC"}}
               mode: {{ $config.stateTransferMode | default $.Values.cacheDefaults.stateTransferMode | quote }} # <4>
               {{- end }}
+            takeOffline:
+              minWait: {{ $config.xsiteOfflineMinWait | default $.Values.cacheDefaults.xsiteOfflineMinWait | quote }}
+              afterFailures: {{ $config.xsiteOfflineAfterFailures | default $.Values.cacheDefaults.xsiteOfflineAfterFailures | quote }}
       {{- end }}
 # end::infinispan-cache-{{ $cache }}[]
 {{end}}

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -13,6 +13,17 @@ cacheDefaults:
   remoteTimeout: 5000
   xsiteRemoteTimeout: 4500
   lockTimeout: 4000
+  # WARN|FAIL|IGNORE. ASYNC only works with WARN|IGNORE
+  xsiteFailurePolicy: WARN
+  # NONE|NON_XA
+  txMode: NONE
+  txLockMode: OPTIMISTIC
+  # If true, then maxRelayNodes must be 1
+  xsiteTwoPhaseCommit: false
+  # Min time to wait
+  xsiteOfflineMinWait: -1
+  # Min consecutive failures
+  xsiteOfflineAfterFailures: -1
 caches:
   sessions:
     owners: 2
@@ -30,6 +41,7 @@ caches:
   work: { }
 crossdc:
   enabled: false
+  maxRelayNodes: 128
   local:
     gossipRouterEnabled: true
   remote:

--- a/provision/rosa-cross-dc/Taskfile.yaml
+++ b/provision/rosa-cross-dc/Taskfile.yaml
@@ -13,6 +13,7 @@ vars:
   ROUTE53_DIR: "{{.ROOT_DIR}}/../aws/route53"
   RDS_DIR: "{{.ROOT_DIR}}/../aws/rds"
   KC_DIR: "{{.ROOT_DIR}}/../openshift"
+  DATASET_DIR: "{{.ROOT_DIR}}/../../dataset"
   ANSIBLE_DIR: "{{.ROOT_DIR}}/../../ansible"
   PYTHON_DIR: "{{.ROOT_DIR}}/../../benchmark/src/main/python"
   BENCHMARK_DIR: "{{.ROOT_DIR}}/../../benchmark/src/main/content/bin"
@@ -614,15 +615,21 @@ tasks:
 
   dataset-import:
     internal: true
+    dir: "{{.DATASET_DIR}}"
     requires:
       vars:
         - KC_URL
     vars:
       USERS: "{{.USERS | default 100000}}"
-      USERS_PER_TX: "{{.USERS_PER_TX | default 256}}"
-      THREADS: "{{.THREADS | default 8}}"
+      CLIENTS: "{{.CLIENTS | default 100}}"
+      REALMS: "{{.REALMS | default 1}}"
+      THREADS: "{{.THREADS | default 12}}"
+      WAIT: "{{.WAIT | default false}}"
+      DATASET_TIMEOUT: "{{.DATASET_TIMEOUT | default 3600}}"
     cmds:
-      - curl -k "https://{{.KC_URL}}/realms/master/dataset/create-realms?realm-name=realm-0&count=1&threads-count={{.THREADS}}&users-per-realm={{.USERS}}&users-per-transaction={{.USERS_PER_TX}}"
+      - ./dataset-import.sh -a clear-status-completed -l https://{{.KC_URL}}/realms/master/dataset
+      - ./dataset-import.sh -a create-realms -l https://{{.KC_URL}}/realms/master/dataset -r {{.REALMS}} -c {{.CLIENTS}} -u {{.USERS}} -C {{.DATASET_TIMEOUT}} -T {{.THREADS}}
+      - ({{if eq .WAIT "true"}}./dataset-import.sh -a status-completed -l https://{{.KC_URL}}/realms/master/dataset -t {{.DATASET_TIMEOUT}}{{else}}echo "Skip Waiting"{{end}})
 
   dataset-import-external:
     desc: "Triggers the dataset creation task using the Route53 or Global Accelerator load balancer. It does not wait for completion."
@@ -687,7 +694,7 @@ tasks:
     vars:
       SCENARIO: '{{.SCENARIO | default "keycloak.scenario.authentication.AuthorizationCode"}}'
       USERS: "{{.USERS | default 100000}}"
-      USERS_PER_SEC: "{{.USERS_PER_SEC | default 300}}"
+      USERS_PER_SEC: "{{.USERS_PER_SEC | default 200}}"
       DURATION: "{{.DURATION | default 600}}"
       REFRESH_TOKEN_COUNT: "{{.REFRESH_TOKEN_COUNT | default 0}}"
       REFRESH_TOKEN_PERIOD: "{{.REFRESH_TOKEN_PERIOD | default 0}}"
@@ -698,11 +705,12 @@ tasks:
         --server-url="https://{{.KC_URL}}/"
         --users-per-sec={{.USERS_PER_SEC}}
         --measurement={{.DURATION}}
-        --realm-name=realm-0
-        --logout-percentage=100
+        --realm-name={{.REALM_NAME | default "realm-0"}}
+        --logout-percentage={{.LOGOUT_PERCENTAGE | default "100"}}
         --users-per-realm={{.USERS}}
-        --ramp-up=100
+        --ramp-up=20
         --log-http-on-failure
+        --sla-error-percentage={{.SLA_ERROR_PERCENTAGE | default "0.001"}}
         --refresh-token-count={{.REFRESH_TOKEN_COUNT}}
         --refresh-token-period={{.REFRESH_TOKEN_PERIOD}}
 


### PR DESCRIPTION
* CROSS_DC_TX_2PC=true|false configures the external Infinispan caches transactions (disabled by default)

Other changes include

* Use 'dataset-import.sh' script in dataset-import-* tasks
* Update ec2-run to match the nightly job
* Automatic take-offline for cross-site enabled by default with 30 sec minimum wait time before switching