### PR TITLE
Distribute clients and user creation between Keycloak nodes

### DIFF
--- a/.github/actions/keycloak-create-dataset/action.yml
+++ b/.github/actions/keycloak-create-dataset/action.yml
@@ -48,6 +48,6 @@ runs:
       shell: bash
       run: |
         ./dataset-import.sh -a clear-status-completed -l ${{ env.KEYCLOAK_URL }}/realms/master/dataset
-        ./dataset-import.sh -a create-clients -c ${{ inputs.clientsPerRealm }} -n ${{ inputs.realmNameForClients }} -l ${{ env.KEYCLOAK_URL }}/realms/master/dataset -C ${{ inputs.maxWaitEntityCreation }} -T 30
+        ./dataset-import.sh -a create-clients -c ${{ inputs.clientsPerRealm }} -n ${{ inputs.realmNameForClients }} -l ${{ env.KEYCLOAK_URL }}/realms/master/dataset -C ${{ inputs.maxWaitEntityCreation }}
         ./dataset-import.sh -a status-completed -t ${{ inputs.maxWaitEntityCreation }} -l ${{ env.KEYCLOAK_URL }}/realms/master/dataset
       working-directory: dataset

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/tasks/BaseDistributedTask.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/tasks/BaseDistributedTask.java
@@ -1,0 +1,114 @@
+package org.keycloak.benchmark.dataset.tasks;
+
+import org.infinispan.commons.util.Util;
+import org.infinispan.executors.LimitedExecutor;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.concurrent.BlockingManager;
+import org.infinispan.util.function.SerializableFunction;
+import org.infinispan.util.function.TriConsumer;
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSessionFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class BaseDistributedTask implements SerializableFunction<EmbeddedCacheManager, String>, TriConsumer<Address, String, Throwable> {
+
+    protected static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final int start;
+    private final int count;
+    private final int concurrency;
+    private final int transactionTimeout;
+    private final String realmName;
+    private final int entitiesPerTransaction;
+
+    protected BaseDistributedTask(String realmName, int start, int count, int concurrency, int entitiesPerTransaction, int transactionTimeout) {
+        this.realmName = realmName;
+        this.start = start;
+        this.count = count;
+        this.concurrency = concurrency;
+        this.transactionTimeout = transactionTimeout;
+        this.entitiesPerTransaction = entitiesPerTransaction;
+    }
+
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public int getEntitiesPerTransaction() {
+        return entitiesPerTransaction;
+    }
+
+    public int getTransactionTimeout() {
+        return transactionTimeout;
+    }
+
+    @Override
+    public String toString() {
+        return ", start=" + start +
+                ", count=" + count +
+                ", concurrency=" + concurrency +
+                ", transactionTimeout=" + transactionTimeout +
+                ", realmName='" + realmName + '\'' +
+                ", entitiesPerTransaction=" + entitiesPerTransaction +
+                '}';
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public final String apply(EmbeddedCacheManager cacheManager) {
+        var sessionFactory = cacheManager.getCache("work").getCacheManager().getGlobalComponentRegistry().getComponent(KeycloakSessionFactory.class, "dataset");
+        if (sessionFactory == null) {
+            throw new IllegalStateException();
+        }
+        var transport = cacheManager.getTransport();
+        var localAddress = transport.getAddress();
+        var clusterSize = transport.getMembers().size();
+        var localIndex = transport.getMembers().indexOf(localAddress);
+        var isLastNode = localIndex == (clusterSize - 1);
+
+        var executor = cacheManager.getGlobalComponentRegistry()
+                .getComponent(BlockingManager.class)
+                .asExecutor("dataset");
+        // BlockingExecutor limitedBlockingExecutor() method is "optimized" to not spawn thread if the invoked is a thread from the "blocking thread pool"
+        // It translates into a sequential run; it is not what we want.
+        // The name is for tracing logging purposes.
+        var limitedExecutor = new LimitedExecutor("dataset-limited", executor, concurrency);
+
+        logger.infof("Node '%s' (index=%s, cluster-size=%s) received a new task: %s", localAddress, localIndex, clusterSize, this);
+
+
+        var clientsPerNode = count / clusterSize;
+        var remainder = count % clusterSize;
+
+        var startIndex = start + (clientsPerNode * localIndex);
+        var endIndex = startIndex + clientsPerNode + (isLastNode ? remainder : 0);
+
+        var startMs = System.currentTimeMillis();
+        var counter = new AtomicInteger();
+
+        runTask(localAddress, sessionFactory, startIndex, endIndex, limitedExecutor, counter);
+
+        var duration = Util.prettyPrintTime(System.currentTimeMillis() - startMs);
+
+        logger.infof("Node '%s' (index=%s, cluster-size=%s) finished task in %s", localAddress, localIndex, clusterSize, duration);
+
+        return String.format("Created %s entities. Took %s", counter.get(), duration);
+    }
+
+    @Override
+    public final void accept(Address src, String rsp, Throwable ex) {
+        if (ex != null) {
+            logger.errorf(ex, "Received error from node %s", src);
+        } else {
+            logger.infof("Received response from node %s: %s", src, rsp);
+        }
+    }
+
+    abstract void runTask(Address localAddress, KeycloakSessionFactory sessionFactory, int startIndex, int endIndex, Executor executor, AtomicInteger counter);
+
+
+}

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/tasks/CreateClientsDistributedTask.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/tasks/CreateClientsDistributedTask.java
@@ -1,0 +1,155 @@
+package org.keycloak.benchmark.dataset.tasks;
+
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.keycloak.benchmark.dataset.config.DatasetConfig;
+import org.keycloak.benchmark.dataset.config.DatasetException;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.KeycloakSessionTask;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.cache.CacheRealmProvider;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CreateClientsDistributedTask extends BaseDistributedTask {
+
+    final String clientPrefix;
+    final String clientAccessType;
+    final boolean serviceAccount;
+    final int clientRolesPerClient;
+    final String clientRolePrefix;
+
+    public CreateClientsDistributedTask(DatasetConfig config) {
+        this(config.getRealmName(), config.getStart(), config.getCount(), config);
+    }
+
+    public CreateClientsDistributedTask(String realmName, int start, int count, DatasetConfig config) {
+        super(realmName, start, count, config.getThreadsCount(), config.getClientsPerTransaction(), config.getTransactionTimeoutInSeconds());
+        clientPrefix = config.getClientPrefix();
+        serviceAccount = Boolean.parseBoolean(config.getIsServiceAccountClient());
+        clientAccessType = config.getClientAccessType();
+        clientRolePrefix = config.getClientRolePrefix();
+        clientRolesPerClient = config.getClientRolesPerClient();
+    }
+
+    @Override
+    void runTask(Address localAddress, KeycloakSessionFactory sessionFactory, int startIndex, int endIndex, Executor executor, AtomicInteger counter) {
+        logger.infof("Node '%s' will create clients from %s (inclusive) to %s (exclusive)", localAddress, startIndex, endIndex);
+        try {
+            AggregateCompletionStage<Void> stage = CompletionStages.aggregateCompletionStage();
+            // Create clients now
+            for (int i = startIndex; i < endIndex; i += getEntitiesPerTransaction()) {
+                var tx = new CreateClientsTx(sessionFactory, counter, i, Math.min(i + getEntitiesPerTransaction(), endIndex), this);
+                // Run this concurrently with multiple threads
+                stage.dependsOn(CompletableFuture.runAsync(tx, executor));
+            }
+            stage.freeze().toCompletableFuture().get();
+        } catch (ExecutionException e) {
+            throw new DatasetException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private record CreateClientsTx(KeycloakSessionFactory sessionFactory, AtomicInteger counter, int startIndex,
+                                   int endIndex,
+                                   CreateClientsDistributedTask task) implements KeycloakSessionTask, Runnable {
+
+        @Override
+        public void run() {
+            KeycloakModelUtils.runJobInTransactionWithTimeout(sessionFactory, this, task.getTransactionTimeout());
+        }
+
+        @Override
+        public void run(KeycloakSession session) {
+            logger.tracef("clientsStartIndex: %d, clientsEndIndex: %d", startIndex, endIndex);
+            RealmModel realm = session.getProvider(RealmProvider.class).getRealmByName(task.getRealmName());
+            if (realm == null) {
+                throw new DatasetException("Realm '" + task.getRealmName() + "' not found");
+            }
+            // Eagerly register invalidation to make sure we don't cache the realm in this transaction. Caching will result in bunch of
+            // unneeded SQL queries (triggered from constructor of org.keycloak.models.cache.infinispan.entities.CachedRealm) and we need to invalidate realm anyway in this transaction
+            RealmProvider realmProvider = session.realms();
+            if (realmProvider instanceof CacheRealmProvider) {
+                ((CacheRealmProvider) realmProvider).registerRealmInvalidation(realm.getId(), realm.getName());
+            }
+
+            // Refresh realm in current transaction
+            realm = realmProvider.getRealm(realm.getId());
+
+            for (int i = startIndex; i < endIndex; i++) {
+                ClientRepresentation client = new ClientRepresentation();
+
+                String clientId = task.clientPrefix + i;
+                client.setClientId(clientId);
+                client.setName(clientId);
+                client.setEnabled(true);
+                client.setDirectAccessGrantsEnabled(true);
+                client.setSecret(clientId.concat("-secret"));
+                client.setRedirectUris(List.of("*"));
+                client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+
+                switch (task.clientAccessType) {
+                    case "bearer-only":
+                        client.setBearerOnly(true);
+                        break;
+                    case "public":
+                        client.setPublicClient(true);
+                        break;
+                    case "confidential":
+                    default:
+                        client.setPublicClient(false);
+                        break;
+                }
+
+                ClientModel model = ClientManager.createClient(session, realm, client);
+
+                // Enable service account
+                if (task.serviceAccount) {
+                    new ClientManager(new RealmManager(session)).enableServiceAccount(model);
+                }
+
+                // Set "post.logout.redirect.uris"
+                if (OIDCAdvancedConfigWrapper.fromClientModel(model).getPostLogoutRedirectUris() == null) {
+                    OIDCAdvancedConfigWrapper.fromClientModel(model).setPostLogoutRedirectUris(Collections.singletonList("+"));
+                }
+
+
+                for (int k = 0; k < task.clientRolesPerClient; k++) {
+                    String roleName = clientId + "-" + task.clientRolePrefix + k;
+                    model.addRole(roleName);
+                }
+                counter.incrementAndGet();
+            }
+            if (((endIndex - startIndex) / task.getEntitiesPerTransaction()) % 20 == 0) {
+                logger.infof("Created %d clients in realm %s", counter.get(), task.getRealmName());
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CreateClientsDistributedTask{" +
+                "clientPrefix='" + clientPrefix + '\'' +
+                ", clientAccessType='" + clientAccessType + '\'' +
+                ", serviceAccount=" + serviceAccount +
+                ", clientRolesPerClient=" + clientRolesPerClient +
+                ", clientRolePrefix='" + clientRolePrefix + '\'' +
+                super.toString();
+    }
+}

--- a/dataset/src/main/java/org/keycloak/benchmark/dataset/tasks/CreateUsersDistributedTask.java
+++ b/dataset/src/main/java/org/keycloak/benchmark/dataset/tasks/CreateUsersDistributedTask.java
@@ -1,0 +1,220 @@
+package org.keycloak.benchmark.dataset.tasks;
+
+import org.infinispan.remoting.transport.Address;
+import org.infinispan.util.concurrent.AggregateCompletionStage;
+import org.infinispan.util.concurrent.CompletionStages;
+import org.keycloak.benchmark.dataset.config.DatasetConfig;
+import org.keycloak.benchmark.dataset.config.DatasetException;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.KeycloakSessionTask;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RealmProvider;
+import org.keycloak.models.RoleContainerModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserCredentialModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.keycloak.benchmark.dataset.DatasetResourceProvider.GROUP_NAME_SEPARATOR;
+
+public class CreateUsersDistributedTask extends BaseDistributedTask {
+
+    private final String realmRolePrefix;
+    private final String groupPrefix;
+    private final String clientPrefix;
+    private final String clientRolePrefix;
+
+    final String userPrefix;
+    final int realmRolesPerUser;
+    final int clientRolesPerUser;
+    final int groupsPerUser;
+
+    public CreateUsersDistributedTask(String realmName, DatasetConfig config) {
+        this(realmName, config.getStart(), config.getCount(), config);
+    }
+
+    public CreateUsersDistributedTask(String realmName, int start, int count, DatasetConfig config) {
+        super(realmName, start, count, config.getThreadsCount(), config.getUsersPerTransaction(), config.getTransactionTimeoutInSeconds());
+        realmRolePrefix = config.getRealmRolePrefix();
+        groupPrefix = config.getGroupPrefix();
+        clientPrefix = config.getClientPrefix();
+        clientRolePrefix = config.getClientRolePrefix();
+        userPrefix = config.getUserPrefix();
+        realmRolesPerUser = config.getRealmRolesPerUser();
+        clientRolesPerUser = config.getClientRolesPerUser();
+        groupsPerUser = config.getGroupsPerUser();
+    }
+
+    @Override
+    void runTask(Address localAddress, KeycloakSessionFactory sessionFactory, int startIndex, int endIndex, Executor executor, AtomicInteger counter) {
+        logger.infof("Node '%s' will create users from %s (inclusive) to %s (exclusive)", localAddress, startIndex, endIndex);
+        try {
+            AggregateCompletionStage<Void> stage = CompletionStages.aggregateCompletionStage();
+            var context = KeycloakModelUtils.runJobInTransactionWithResult(sessionFactory, this::createUserContext);
+            // Create clients now
+            for (int i = startIndex; i < endIndex; i += getEntitiesPerTransaction()) {
+                var tx = new CreateUsersTx(sessionFactory, context, counter, i, Math.min(i + getEntitiesPerTransaction(), endIndex), this);
+                // Run this concurrently with multiple threads
+                stage.dependsOn(CompletableFuture.runAsync(tx, executor));
+            }
+            stage.freeze().toCompletableFuture().get();
+        } catch (ExecutionException e) {
+            throw new DatasetException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private UserContext createUserContext(KeycloakSession session) {
+        RealmModel realm = session.getProvider(RealmProvider.class).getRealmByName(getRealmName());
+
+        List<RoleModel> realmRoles = realm.getRolesStream()
+                .filter(roleModel -> roleModel.getName().startsWith(realmRolePrefix))
+                .sorted((role1, role2) -> {
+                    String name1 = role1.getName().substring(realmRolePrefix.length());
+                    String name2 = role2.getName().substring(realmRolePrefix.length());
+                    return Integer.parseInt(name1) - Integer.parseInt(name2);
+                })
+                .collect(Collectors.toList());
+
+        logger.debugf("CACHE: After obtain realm roles in realm %s", realm.getName());
+
+        List<GroupModel> sortedGroups = realm.getGroupsStream()
+                .filter(groupModel -> groupModel.getName().startsWith(groupPrefix))
+                .sorted((group1, group2) -> {
+                    String name1 = group1.getName().substring(groupPrefix.length());
+                    String name2 = group2.getName().substring(groupPrefix.length());
+                    String[] name1Exploded = name1.split(Pattern.quote(GROUP_NAME_SEPARATOR));
+                    String[] name2Exploded = name2.split(Pattern.quote(GROUP_NAME_SEPARATOR));
+                    for (int i = 0; i < Math.min(name1Exploded.length, name2Exploded.length); i++) {
+                        if (name1Exploded[i].compareTo(name2Exploded[i]) != 0) {
+                            return name1Exploded[i].compareTo(name2Exploded[i]);
+                        }
+                    }
+                    return name1.compareTo(name2);
+                })
+                .collect(Collectors.toList());
+
+        List<RoleModel> clientRoles = realm.getClientsStream(0, 20)
+                .filter(clientModel -> clientModel.getClientId().startsWith(clientPrefix))
+                .sorted((client1, client2) -> {
+                    String name1 = client1.getClientId().substring(clientPrefix.length());
+                    String name2 = client2.getClientId().substring(clientPrefix.length());
+                    return Integer.parseInt(name1) - Integer.parseInt(name2);
+                })
+                .flatMap(RoleContainerModel::getRolesStream)
+                .filter(roleModel -> roleModel.getName().startsWith(clientPrefix))
+                .sorted((role1, role2) -> {
+                    int index1 = role1.getName().indexOf(clientRolePrefix) + clientRolePrefix.length();
+                    int index2 = role2.getName().indexOf(clientRolePrefix) + clientRolePrefix.length();
+                    String name1 = role1.getName().substring(index1);
+                    String name2 = role2.getName().substring(index2);
+                    return Integer.parseInt(name1) - Integer.parseInt(name2);
+                })
+                .collect(Collectors.toList());
+
+        logger.debugf("CACHE: After client roles loaded in the realm %s", realm.getName());
+        return new UserContext(realmRoles, clientRoles, sortedGroups);
+    }
+
+    @Override
+    public String toString() {
+        return "CreateUsersDistributedTask{" +
+                "realmRolePrefix='" + realmRolePrefix + '\'' +
+                ", groupPrefix='" + groupPrefix + '\'' +
+                ", clientPrefix='" + clientPrefix + '\'' +
+                ", clientRolePrefix='" + clientRolePrefix + '\'' +
+                ", userPrefix='" + userPrefix + '\'' +
+                ", realmRolesPerUser=" + realmRolesPerUser +
+                ", clientRolesPerUser=" + clientRolesPerUser +
+                ", groupsPerUser=" + groupsPerUser +
+                super.toString();
+    }
+
+    record UserContext(List<RoleModel> realmRoles, List<RoleModel> clientRoles, List<GroupModel> groups) {
+
+        RoleModel getRealmRole(int index) {
+            var roleIndex = index % realmRoles.size();
+            return realmRoles.get(roleIndex);
+        }
+
+        RoleModel getClientRole(int index) {
+            var roleIndex = index % clientRoles.size();
+            return clientRoles.get(roleIndex);
+        }
+
+        GroupModel getGroup(int index) {
+            var groupIndex = index % groups.size();
+            return groups.get(groupIndex);
+        }
+
+    }
+
+    private record CreateUsersTx(KeycloakSessionFactory sessionFactory, UserContext context, AtomicInteger counter,
+                                 int startIndex, int endIndex,
+                                 CreateUsersDistributedTask task) implements KeycloakSessionTask, Runnable {
+
+        @Override
+        public void run() {
+            KeycloakModelUtils.runJobInTransactionWithTimeout(sessionFactory, this, task.getTransactionTimeout());
+        }
+
+        @Override
+        public void run(KeycloakSession session) {
+            RealmModel realm = session.realms().getRealm(task.getRealmName());
+
+            for (int i = startIndex; i < endIndex; i++) {
+                String username = task.userPrefix + i;
+                UserModel user = session.users().addUser(realm, username);
+                user.setEnabled(true);
+                user.setFirstName(username + "-first");
+                user.setLastName(username + "-last");
+                user.setEmail(username + String.format("@%s.com", realm.getName()));
+
+                String password = String.format("%s-password", username);
+                user.credentialManager().updateCredential(UserCredentialModel.password(password, false));
+
+                // Detect which roles we assign to the user
+                int roleIndexStartForCurrentUser = (i * task.realmRolesPerUser);
+                for (int j = roleIndexStartForCurrentUser; j < roleIndexStartForCurrentUser + task.realmRolesPerUser; j++) {
+                    var role = context.getRealmRole(j);
+                    user.grantRole(role);
+
+                    logger.tracef("Assigned role %s to the user %s", role.getName(), user.getUsername());
+                }
+
+                int clientRoleIndexStartForCurrentUser = (i * task.clientRolesPerUser);
+                for (int j = clientRoleIndexStartForCurrentUser; j < clientRoleIndexStartForCurrentUser + task.clientRolesPerUser; j++) {
+                    var role = context.getClientRole(j);
+                    user.grantRole(role);
+
+                    logger.tracef("Assigned role %s to the user %s", role.getName(), user.getUsername());
+                }
+
+                // Detect which groups we assign to the user
+                int groupIndexStartForCurrentUser = (i * task.groupsPerUser);
+                for (int j = groupIndexStartForCurrentUser; j < groupIndexStartForCurrentUser + task.groupsPerUser; j++) {
+                    var group = context.getGroup(j);
+                    user.joinGroup(group);
+
+                    logger.tracef("Assigned group %s to the user %s", group.getName(), user.getUsername());
+                }
+                counter.incrementAndGet();
+            }
+
+            if (((endIndex - startIndex) / task.getEntitiesPerTransaction()) % 20 == 0) {
+                logger.infof("Created %d users in realm %s", counter.get(), task.getRealmName());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Results comparing with today's nightly run:

### Creating Realms

Command: `./dataset-import.sh -a create-realms -r 1 -c 100 -u 20000 -l <URL> -C 10800`

From the GH actions log:
```
{"status":"previous task completed","task":{"success":"true","startTimeMs":"1710404388704","message":"Creation of 1 realms from realm-0 to realm-0","endTimeMs":"1710405084227"}}
```
Duration: 695_523 ms

From this PR:
```
{"status":"previous task completed","task":{"success":"true","startTimeMs":"1710409882949","message":"Creation of 1 realms from realm-0 to realm-0","endTimeMs":"1710410166190"}}
```
Duration: 283_241 ms

### Creating clients

Command: `./dataset-import.sh -a create-clients -c 20000 -n realm-0 -l <URL> -C 10800 -T 30`

From the GH actions log:
```
{"status":"previous task completed","task":{"success":"true","startTimeMs":"1710405087119","message":"Creation of 20000 clients in the realm realm-0","endTimeMs":"1710405245083"}}
```
Duration: 157_964 ms

From this PR:
```
{"status":"previous task completed","task":{"success":"true","startTimeMs":"1710410430494","message":"Creation of 20000 clients in the realm realm-0","endTimeMs":"1710410645228"}}
```
Duration: 214_734 ms

The client creation does not look CPU bounded, so I repeated the steps with the default number of threads:
```
{"status":"previous task completed","task":{"success":"true","startTimeMs":"1710410915785","message":"Creation of 20000 clients in the realm realm-0","endTimeMs":"1710411120861"}}
```
Duration: 205_076 ms

In both scenarios, distributing the clients creation seems slow instead of using a single node :shrug: 