### PR TITLE
Fix cleaning up of the failover lambda

### DIFF
--- a/provision/aws/route53/route53_delete.sh
+++ b/provision/aws/route53/route53_delete.sh
@@ -20,8 +20,9 @@ HEALTH_CHECKS=$(aws route53 list-health-checks \
   --output json
 )
 echo ${HEALTH_CHECKS} | jq -c '.[]' | while read HEALTH_CHECK; do
-  HEALTH_CHECK_ID=${HEALTH_CHECK} ${SCRIPT_DIR}/route53_delete_failover_lambda.sh
-  aws route53 delete-health-check --health-check-id $(echo ${HEALTH_CHECK} | jq -r .Id)
+  HEALTH_CHECK_ID=$(echo ${HEALTH_CHECK} | jq -r .Id)
+  HEALTH_CHECK_ID=${HEALTH_CHECK_ID} ${SCRIPT_DIR}/route53_delete_failover_lambda.sh
+  aws route53 delete-health-check --health-check-id ${HEALTH_CHECK_ID}
 done
 
 # Delete Hosted Zone records


### PR DESCRIPTION
It seems CloudWatch alarms and SNS topics are not cleaned correctly by the nightly run. There is the following error in the output logs:
```
An error occurred (ValidationException) when calling the DeleteFunction operation: 2 validation errors detected: Value '{"Id":"03a282bd-4954-4c9d-a950-29cef7d682d4","CallerReference":"d54738171435725144e3d2ed900ec890c7b1d04d","HealthCheckConfig":{"Port":443,"Type":"HTTPS","ResourcePath":"/lb-check","FullyQualifiedDomainName":"primary.gh-keycloak-a-gh-keycloak-b-mtq5mtkk.keycloak-benchmark.com","RequestInterval":30,"FailureThreshold":1,"MeasureLatency":false,"Inverted":false,"Disabled":false,"EnableSNI":true},"HealthCheckVersion":6}' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?; Value '{"Id":"03a282bd-4954-4c9d-a950-29cef7d682d4","CallerReference":"d54738171435725144e3d2ed900ec890c7b1d04d","HealthCheckConfig":{"Port":443,"Type":"HTTPS","ResourcePath":"/lb-check","FullyQualifiedDomainName":"primary.gh-keycloak-a-gh-keycloak-b-mtq5mtkk.keycloak-benchmark.com","RequestInterval":30,"FailureThreshold":1,"MeasureLatency":false,"Inverted":false,"Disabled":false,"EnableSNI":true},"HealthCheckVersion":6}' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 140
```

Example run: https://github.com/keycloak/keycloak-benchmark/actions/runs/8459228754/job/23175145506

There are some dangling alarms, see:
https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2: