### PR TITLE
Fix removed iterations in docs and minikube CI

### DIFF
--- a/.github/workflows/provision-minikube.yml
+++ b/.github/workflows/provision-minikube.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: provision/minikube
         run: |
           task KC_DATABASE=postgres dataset-import -- -a clear-status-completed
-          task KC_DATABASE=postgres dataset-import -- -a create-realms -r 1 -c 5 -u 5 -i 1000
+          task KC_DATABASE=postgres dataset-import -- -a create-realms -r 1 -c 5 -u 5
           task KC_DATABASE=postgres dataset-import -- -a status-completed
       - name: Show logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -14,7 +14,7 @@ on:
       numberOfEntitiesInRealm:
         description: 'Number of entities for the scenario in DB'
         type: number
-        default: 20000
+        default: 100000
       maxWaitEntityCreation:
         description: 'Maximum number of seconds to wait for creation of entities'
         type: number
@@ -57,7 +57,7 @@ on:
       numberOfEntitiesInRealm:
         description: 'Number of entities for the scenario in DB'
         type: number
-        default: 20000
+        default: 100000
       maxWaitEntityCreation:
         description: 'Maximum number of seconds to wait for creation of entities'
         type: number

--- a/dataset/dataset-import.sh
+++ b/dataset/dataset-import.sh
@@ -74,7 +74,7 @@ set_environment_variables () {
 
 create_realms () {
   echo "Creating $1 realm/s with $2 client/s and $3 user/s."
-  execute_command "create-realms?count=$1&clients-per-realm=$2&users-per-realm=$3&task-timeout=$5&threads-count=$6"
+  execute_command "create-realms?count=$1&clients-per-realm=$2&users-per-realm=$3&task-timeout=$4&threads-count=$5"
 }
 
 create_clients () {

--- a/doc/benchmark/modules/ROOT/pages/scenario/list-sessions.adoc
+++ b/doc/benchmark/modules/ROOT/pages/scenario/list-sessions.adoc
@@ -73,7 +73,7 @@ curl 'https://keycloak-server/realms/master/dataset/create-realms?realm-name=rea
 .Alternative 2: Setup of users and clients using the `dataset-import.sh` shell script
 [source,bash]
 ----
-./dataset-import.sh -a create-realms -r 1 -c 5 -u 30 -i 1000
+./dataset-import.sh -a create-realms -r 1 -c 5 -u 30
 ----
 
 === Running the scenario


### PR DESCRIPTION
- Update the position of the threads-count and task-timeout args inside the dataset-import.sh script under dataset module
- Moving back to creating 100k users given the changes in the hashing algo and iterations