### PR TITLE
Upgrade to terraform-redhat/rhcs 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ provision/environment_data.json
 # OpenTofu / Terraform
 **/*.tfstate*
 **/*.terraform*
+!**/*.terraform.lock.hcl

--- a/provision/aws/rosa_efs_create.sh
+++ b/provision/aws/rosa_efs_create.sh
@@ -90,8 +90,8 @@ EOF
 
 oc apply -f efs-csi-aws-com-cluster-csi-driver.yaml
 
-kubectl wait --for=condition=AWSEFSDriverNodeServiceControllerAvailable --timeout=300s clustercsidriver.operator.openshift.io/efs.csi.aws.com
-kubectl wait --for=condition=AWSEFSDriverControllerServiceControllerAvailable --timeout=300s clustercsidriver.operator.openshift.io/efs.csi.aws.com
+kubectl wait --for=condition=AWSEFSDriverNodeServiceControllerAvailable --timeout=450s clustercsidriver.operator.openshift.io/efs.csi.aws.com
+kubectl wait --for=condition=AWSEFSDriverControllerServiceControllerAvailable --timeout=450s clustercsidriver.operator.openshift.io/efs.csi.aws.com
 
 NODE=$(oc get nodes --selector=node-role.kubernetes.io/worker \
   -o jsonpath='{.items[0].metadata.name}')

--- a/provision/opentofu/modules/rosa/account-roles/.terraform.lock.hcl
+++ b/provision/opentofu/modules/rosa/account-roles/.terraform.lock.hcl
@@ -1,0 +1,69 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.43.0"
+  constraints = ">= 4.0.0, >= 5.38.0"
+  hashes = [
+    "h1:9l6juBAwKzO2AdL+SS2J3B1q4s8DpAzHLMb0Jbsp5VM=",
+    "zh:2920f88c31ef2733737d2370ce42c237205274f37fd02deaaff6357f6faeb731",
+    "zh:3cf8766f2de846932fe3b90e17dd2d6eff96cb0acb600420a1c139c68001e44a",
+    "zh:4a6b7a024fcf98a622bc64ec565df19bfac93c612942e90b2a321c86ee8e8f24",
+    "zh:756d129653c4e4c88537a635f2f3bc34ab6fa91827406a1efda52e502f057c75",
+    "zh:8b23287ebf67e1f32647a11933519da7895b1f4970d1ff58cd7b06f5eb1c42c4",
+    "zh:9a423b09ce6680ff5ff655c908977ec30cc44eedee7e2e3a09cc55af3f9edc4c",
+    "zh:aeb593ce863fa4b97b891a3772c660200e2d55b38eb152f92f377a3402fa7e76",
+    "zh:cb3c7a578a2ab507ac74f819f831afcbe343441eae26e8f77727c9597afe827d",
+    "zh:de9eaaf0f8ee2e2116ff664ceefefae97b93f14ce2103494b95f1d59e4ce60d7",
+    "zh:e27cb09ebc09a8327ccf1c4b2c27a1fcaebbdb3da15cac0aeff10b1f9e436cd7",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version = "3.6.0"
+  hashes = [
+    "h1:/xwPFz7kMERBIEk8i6UJt2fTvgzMFbwKlcyCvRJO8Ok=",
+    "zh:486a1c921eab5c51a480f2eb0ad85173f207c9b7bb215f3893e58bc38d3b7c75",
+    "zh:6901b3afa4607d1e31934ba91ed2625215ada42b3518c3a9adeeac7a5f656dc3",
+    "zh:7e93752c9de710e417191353ad1a41b5a60432ab7ef4f8b556bf248297ec5e23",
+    "zh:c795d3d319e8ee7be972746b935963b7e772a6a14080261a35c03915c1f9ccb2",
+    "zh:cd4f8bcaf332828d1736c73874549c25e427737f136173c7b61e2df3db50e5d9",
+    "zh:e0103eb2e280989c3d9ffda5d6b413e8f583be21bc1d5754c6e9ca87ecc1c44a",
+    "zh:f4fbec2510322d5b7ad584a92436b5dbd0f2e897a3ec538932af59e245a4c8e4",
+    "zh:f5418842afd4aa7676e2456e425e8f573cb2b9bffd29bd7de09d91845644ab24",
+    "zh:f572a26f93d00ec42461ce478678366e570fa4497e2273f9d47f24cdfc4b42b4",
+    "zh:ff1f07c561a3f7f219b6fee1647a559933b5dd6181753e164c3978fd47a11685",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version = "0.11.1"
+  hashes = [
+    "h1:HSQ/mQFgGE6du6H/v4eCPKpUjQEy3mknmPBDNXoz9g0=",
+    "zh:048c56f9f810f67a7460363a26bf3ef939d64f0d7b7342b9e7f24cc85ee1491b",
+    "zh:49f949cc5cb50fbb65f7b4578b79fbe02b6bafe9e3f5f1c2936114dd445b84b3",
+    "zh:553174a4fa88f6e186800d7ee155a6b5b4c6c81793643f1a20eab26becc7f823",
+    "zh:5cae304e21f77091d4b50389c655afd5e4e2e8d4cd9c06de139a31b8e7d343a9",
+    "zh:7aae20832bd9885f034831aa44db3a6ffcec034a2d5a2815d92c42c40c14ca1d",
+    "zh:93d715610dce777474b5eff1d7dbe797e72ca0b679cd8636efb3aa45d1cb589e",
+    "zh:bd29e04645775851eb10e7f3b39104ae57ca3632dec4ae07328d33d4182e7fb5",
+    "zh:d6ad6a4d52a6989b8452466f2ec3dbcdb00cc44a96bd1ca618d91a5d74895f49",
+    "zh:e68cfad3ec526631410fa9406938d624fd56b9ab065c76525cb3f731d106fbfe",
+    "zh:ffee8aa6b7ce56f4b8fdc0c492404be0041137a278388eb1d1180b637fb5b3de",
+  ]
+}
+
+provider "registry.opentofu.org/terraform-redhat/rhcs" {
+  version     = "1.6.0"
+  constraints = "1.6.0"
+  hashes = [
+    "h1:cdcloXTIpCNYKGFfEX2YC6c1y7v22UIoVdzEwq5YgUY=",
+    "zh:7c38e8243f45da13a4551239be473da210295181ec47c1e94cfed5dbbbe1f54b",
+    "zh:7ece7b3c1039d600c7d4b22c635bbd0e8d24e942dc55cd6548c90f3defdc4ea6",
+    "zh:843875cfb16421daf39c8a339923cdbd9ad96e369caebeeca6a67824cb17011d",
+    "zh:b3fff8460fc26facb0ff1404aeaec525019453f7a0609f3485146f8cd99d6b1d",
+    "zh:d840a5c54f79608605f6b0f648eefb77d88a8cb8568b18e423aa0170afd39ae7",
+    "zh:e976333fb0360cc3ef1bc016d1b62471b447e7ab5c9a46d90ad3233f3581c6f2",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/provision/opentofu/modules/rosa/account-roles/provider.tf
+++ b/provision/opentofu/modules/rosa/account-roles/provider.tf
@@ -6,7 +6,7 @@ terraform {
     }
     rhcs = {
       source = "terraform-redhat/rhcs"
-      version = "1.6.0-prerelease.1"
+      version = "1.6.0"
     }
   }
 }

--- a/provision/opentofu/modules/rosa/hcp/.terraform.lock.hcl
+++ b/provision/opentofu/modules/rosa/hcp/.terraform.lock.hcl
@@ -1,0 +1,106 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.43.0"
+  constraints = ">= 4.0.0, >= 4.35.0, >= 5.0.0, >= 5.27.0, >= 5.38.0"
+  hashes = [
+    "h1:9l6juBAwKzO2AdL+SS2J3B1q4s8DpAzHLMb0Jbsp5VM=",
+    "zh:2920f88c31ef2733737d2370ce42c237205274f37fd02deaaff6357f6faeb731",
+    "zh:3cf8766f2de846932fe3b90e17dd2d6eff96cb0acb600420a1c139c68001e44a",
+    "zh:4a6b7a024fcf98a622bc64ec565df19bfac93c612942e90b2a321c86ee8e8f24",
+    "zh:756d129653c4e4c88537a635f2f3bc34ab6fa91827406a1efda52e502f057c75",
+    "zh:8b23287ebf67e1f32647a11933519da7895b1f4970d1ff58cd7b06f5eb1c42c4",
+    "zh:9a423b09ce6680ff5ff655c908977ec30cc44eedee7e2e3a09cc55af3f9edc4c",
+    "zh:aeb593ce863fa4b97b891a3772c660200e2d55b38eb152f92f377a3402fa7e76",
+    "zh:cb3c7a578a2ab507ac74f819f831afcbe343441eae26e8f77727c9597afe827d",
+    "zh:de9eaaf0f8ee2e2116ff664ceefefae97b93f14ce2103494b95f1d59e4ce60d7",
+    "zh:e27cb09ebc09a8327ccf1c4b2c27a1fcaebbdb3da15cac0aeff10b1f9e436cd7",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/external" {
+  version = "2.3.3"
+  hashes = [
+    "h1:bDJy8Mj5PMTEuxm6Wu9A9dATBL+mQDmHx8NnLzjvCcc=",
+    "zh:1ec36864a1872abdfd1c53ba3c6837407564ac0d86ab80bf4fdc87b41106fe68",
+    "zh:2117e0edbdc88f0d22fe02fe6b2cfbbbc5d5ce40f8f58e484d8d77d64dd7340f",
+    "zh:4bcfdacd8e2508c16e131de9072cecd359e0ade3b8c6798a049883f37a5872ea",
+    "zh:4da71bc601a37bf8b7413c142d43f5f28e97e531d4836ee8624f41b9fb62e250",
+    "zh:55b9eebac79a46f88db5615f1ee0ac4c3f9351caa4eb8542171ef5d87de60338",
+    "zh:74d64afaef190321f8ddf1c4a9c6489d6cf51098704a2456c1553406e8306328",
+    "zh:8a357e51a0ec69872fafc64da3c6a1039277d325255ef5a264b727d83995d18b",
+    "zh:aacd2e6c13fe19115d51cd28a40a28da017bb48c2e18dec4460d1c37506b1495",
+    "zh:e19c8bdf0e059341d008a50f9138c44009e9ebb3a8047a300e6bc63ed8af8ea0",
+    "zh:fafa9639d8b8402e35f3864c6cfb0762ec57cc365a8f383e2acf81105b1b9eea",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = ">= 3.0.0, ~> 3.2"
+  hashes = [
+    "h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
+    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
+    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
+    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
+    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
+    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
+    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
+    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
+    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.6.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:/xwPFz7kMERBIEk8i6UJt2fTvgzMFbwKlcyCvRJO8Ok=",
+    "zh:486a1c921eab5c51a480f2eb0ad85173f207c9b7bb215f3893e58bc38d3b7c75",
+    "zh:6901b3afa4607d1e31934ba91ed2625215ada42b3518c3a9adeeac7a5f656dc3",
+    "zh:7e93752c9de710e417191353ad1a41b5a60432ab7ef4f8b556bf248297ec5e23",
+    "zh:c795d3d319e8ee7be972746b935963b7e772a6a14080261a35c03915c1f9ccb2",
+    "zh:cd4f8bcaf332828d1736c73874549c25e427737f136173c7b61e2df3db50e5d9",
+    "zh:e0103eb2e280989c3d9ffda5d6b413e8f583be21bc1d5754c6e9ca87ecc1c44a",
+    "zh:f4fbec2510322d5b7ad584a92436b5dbd0f2e897a3ec538932af59e245a4c8e4",
+    "zh:f5418842afd4aa7676e2456e425e8f573cb2b9bffd29bd7de09d91845644ab24",
+    "zh:f572a26f93d00ec42461ce478678366e570fa4497e2273f9d47f24cdfc4b42b4",
+    "zh:ff1f07c561a3f7f219b6fee1647a559933b5dd6181753e164c3978fd47a11685",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.11.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:HSQ/mQFgGE6du6H/v4eCPKpUjQEy3mknmPBDNXoz9g0=",
+    "zh:048c56f9f810f67a7460363a26bf3ef939d64f0d7b7342b9e7f24cc85ee1491b",
+    "zh:49f949cc5cb50fbb65f7b4578b79fbe02b6bafe9e3f5f1c2936114dd445b84b3",
+    "zh:553174a4fa88f6e186800d7ee155a6b5b4c6c81793643f1a20eab26becc7f823",
+    "zh:5cae304e21f77091d4b50389c655afd5e4e2e8d4cd9c06de139a31b8e7d343a9",
+    "zh:7aae20832bd9885f034831aa44db3a6ffcec034a2d5a2815d92c42c40c14ca1d",
+    "zh:93d715610dce777474b5eff1d7dbe797e72ca0b679cd8636efb3aa45d1cb589e",
+    "zh:bd29e04645775851eb10e7f3b39104ae57ca3632dec4ae07328d33d4182e7fb5",
+    "zh:d6ad6a4d52a6989b8452466f2ec3dbcdb00cc44a96bd1ca618d91a5d74895f49",
+    "zh:e68cfad3ec526631410fa9406938d624fd56b9ab065c76525cb3f731d106fbfe",
+    "zh:ffee8aa6b7ce56f4b8fdc0c492404be0041137a278388eb1d1180b637fb5b3de",
+  ]
+}
+
+provider "registry.opentofu.org/terraform-redhat/rhcs" {
+  version     = "1.6.0"
+  constraints = "1.6.0"
+  hashes = [
+    "h1:cdcloXTIpCNYKGFfEX2YC6c1y7v22UIoVdzEwq5YgUY=",
+    "zh:7c38e8243f45da13a4551239be473da210295181ec47c1e94cfed5dbbbe1f54b",
+    "zh:7ece7b3c1039d600c7d4b22c635bbd0e8d24e942dc55cd6548c90f3defdc4ea6",
+    "zh:843875cfb16421daf39c8a339923cdbd9ad96e369caebeeca6a67824cb17011d",
+    "zh:b3fff8460fc26facb0ff1404aeaec525019453f7a0609f3485146f8cd99d6b1d",
+    "zh:d840a5c54f79608605f6b0f648eefb77d88a8cb8568b18e423aa0170afd39ae7",
+    "zh:e976333fb0360cc3ef1bc016d1b62471b447e7ab5c9a46d90ad3233f3581c6f2",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/provision/opentofu/modules/rosa/hcp/provider.tf
+++ b/provision/opentofu/modules/rosa/hcp/provider.tf
@@ -18,7 +18,7 @@ terraform {
     }
     rhcs = {
       source = "terraform-redhat/rhcs"
-      version = "1.6.0-prerelease.2"
+      version = "1.6.0"
     }
   }
 

--- a/provision/opentofu/modules/rosa/oidc-provider-operator-roles/.terraform.lock.hcl
+++ b/provision/opentofu/modules/rosa/oidc-provider-operator-roles/.terraform.lock.hcl
@@ -1,0 +1,89 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.43.0"
+  constraints = ">= 4.0.0, >= 5.0.0, >= 5.27.0, >= 5.38.0"
+  hashes = [
+    "h1:9l6juBAwKzO2AdL+SS2J3B1q4s8DpAzHLMb0Jbsp5VM=",
+    "zh:2920f88c31ef2733737d2370ce42c237205274f37fd02deaaff6357f6faeb731",
+    "zh:3cf8766f2de846932fe3b90e17dd2d6eff96cb0acb600420a1c139c68001e44a",
+    "zh:4a6b7a024fcf98a622bc64ec565df19bfac93c612942e90b2a321c86ee8e8f24",
+    "zh:756d129653c4e4c88537a635f2f3bc34ab6fa91827406a1efda52e502f057c75",
+    "zh:8b23287ebf67e1f32647a11933519da7895b1f4970d1ff58cd7b06f5eb1c42c4",
+    "zh:9a423b09ce6680ff5ff655c908977ec30cc44eedee7e2e3a09cc55af3f9edc4c",
+    "zh:aeb593ce863fa4b97b891a3772c660200e2d55b38eb152f92f377a3402fa7e76",
+    "zh:cb3c7a578a2ab507ac74f819f831afcbe343441eae26e8f77727c9597afe827d",
+    "zh:de9eaaf0f8ee2e2116ff664ceefefae97b93f14ce2103494b95f1d59e4ce60d7",
+    "zh:e27cb09ebc09a8327ccf1c4b2c27a1fcaebbdb3da15cac0aeff10b1f9e436cd7",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.2"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
+    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
+    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
+    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
+    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
+    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
+    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
+    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
+    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.6.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:/xwPFz7kMERBIEk8i6UJt2fTvgzMFbwKlcyCvRJO8Ok=",
+    "zh:486a1c921eab5c51a480f2eb0ad85173f207c9b7bb215f3893e58bc38d3b7c75",
+    "zh:6901b3afa4607d1e31934ba91ed2625215ada42b3518c3a9adeeac7a5f656dc3",
+    "zh:7e93752c9de710e417191353ad1a41b5a60432ab7ef4f8b556bf248297ec5e23",
+    "zh:c795d3d319e8ee7be972746b935963b7e772a6a14080261a35c03915c1f9ccb2",
+    "zh:cd4f8bcaf332828d1736c73874549c25e427737f136173c7b61e2df3db50e5d9",
+    "zh:e0103eb2e280989c3d9ffda5d6b413e8f583be21bc1d5754c6e9ca87ecc1c44a",
+    "zh:f4fbec2510322d5b7ad584a92436b5dbd0f2e897a3ec538932af59e245a4c8e4",
+    "zh:f5418842afd4aa7676e2456e425e8f573cb2b9bffd29bd7de09d91845644ab24",
+    "zh:f572a26f93d00ec42461ce478678366e570fa4497e2273f9d47f24cdfc4b42b4",
+    "zh:ff1f07c561a3f7f219b6fee1647a559933b5dd6181753e164c3978fd47a11685",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.11.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:HSQ/mQFgGE6du6H/v4eCPKpUjQEy3mknmPBDNXoz9g0=",
+    "zh:048c56f9f810f67a7460363a26bf3ef939d64f0d7b7342b9e7f24cc85ee1491b",
+    "zh:49f949cc5cb50fbb65f7b4578b79fbe02b6bafe9e3f5f1c2936114dd445b84b3",
+    "zh:553174a4fa88f6e186800d7ee155a6b5b4c6c81793643f1a20eab26becc7f823",
+    "zh:5cae304e21f77091d4b50389c655afd5e4e2e8d4cd9c06de139a31b8e7d343a9",
+    "zh:7aae20832bd9885f034831aa44db3a6ffcec034a2d5a2815d92c42c40c14ca1d",
+    "zh:93d715610dce777474b5eff1d7dbe797e72ca0b679cd8636efb3aa45d1cb589e",
+    "zh:bd29e04645775851eb10e7f3b39104ae57ca3632dec4ae07328d33d4182e7fb5",
+    "zh:d6ad6a4d52a6989b8452466f2ec3dbcdb00cc44a96bd1ca618d91a5d74895f49",
+    "zh:e68cfad3ec526631410fa9406938d624fd56b9ab065c76525cb3f731d106fbfe",
+    "zh:ffee8aa6b7ce56f4b8fdc0c492404be0041137a278388eb1d1180b637fb5b3de",
+  ]
+}
+
+provider "registry.opentofu.org/terraform-redhat/rhcs" {
+  version     = "1.6.0"
+  constraints = "1.6.0"
+  hashes = [
+    "h1:cdcloXTIpCNYKGFfEX2YC6c1y7v22UIoVdzEwq5YgUY=",
+    "zh:7c38e8243f45da13a4551239be473da210295181ec47c1e94cfed5dbbbe1f54b",
+    "zh:7ece7b3c1039d600c7d4b22c635bbd0e8d24e942dc55cd6548c90f3defdc4ea6",
+    "zh:843875cfb16421daf39c8a339923cdbd9ad96e369caebeeca6a67824cb17011d",
+    "zh:b3fff8460fc26facb0ff1404aeaec525019453f7a0609f3485146f8cd99d6b1d",
+    "zh:d840a5c54f79608605f6b0f648eefb77d88a8cb8568b18e423aa0170afd39ae7",
+    "zh:e976333fb0360cc3ef1bc016d1b62471b447e7ab5c9a46d90ad3233f3581c6f2",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/provision/opentofu/modules/rosa/oidc-provider-operator-roles/provider.tf
+++ b/provision/opentofu/modules/rosa/oidc-provider-operator-roles/provider.tf
@@ -8,7 +8,7 @@ terraform {
     }
     rhcs = {
       source = "terraform-redhat/rhcs"
-      version = "1.6.0-prerelease.1"
+      version = "1.6.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/provision/opentofu/modules/rosa/vpc/.terraform.lock.hcl
+++ b/provision/opentofu/modules/rosa/vpc/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.43.0"
+  constraints = ">= 4.35.0"
+  hashes = [
+    "h1:9l6juBAwKzO2AdL+SS2J3B1q4s8DpAzHLMb0Jbsp5VM=",
+    "zh:2920f88c31ef2733737d2370ce42c237205274f37fd02deaaff6357f6faeb731",
+    "zh:3cf8766f2de846932fe3b90e17dd2d6eff96cb0acb600420a1c139c68001e44a",
+    "zh:4a6b7a024fcf98a622bc64ec565df19bfac93c612942e90b2a321c86ee8e8f24",
+    "zh:756d129653c4e4c88537a635f2f3bc34ab6fa91827406a1efda52e502f057c75",
+    "zh:8b23287ebf67e1f32647a11933519da7895b1f4970d1ff58cd7b06f5eb1c42c4",
+    "zh:9a423b09ce6680ff5ff655c908977ec30cc44eedee7e2e3a09cc55af3f9edc4c",
+    "zh:aeb593ce863fa4b97b891a3772c660200e2d55b38eb152f92f377a3402fa7e76",
+    "zh:cb3c7a578a2ab507ac74f819f831afcbe343441eae26e8f77727c9597afe827d",
+    "zh:de9eaaf0f8ee2e2116ff664ceefefae97b93f14ce2103494b95f1d59e4ce60d7",
+    "zh:e27cb09ebc09a8327ccf1c4b2c27a1fcaebbdb3da15cac0aeff10b1f9e436cd7",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:xN1tSeF/rUBfaddk/AVqk4i65z/MMM9uVZWd2cWCCH0=",
+    "zh:00e5877d19fb1c1d8c4b3536334a46a5c86f57146fd115c7b7b4b5d2bf2de86d",
+    "zh:1755c2999e73e4d73f9de670c145c9a0dc5a373802799dff06a0e9c161354163",
+    "zh:2b29d706353bc9c4edda6a2946af3322abe94372ffb421d81fa176f1e57e33be",
+    "zh:34f65259c6d2bd51582b6da536e782b181b23725782b181193b965f519fbbacd",
+    "zh:370f6eb744475926a1fa7464d82d46ad83c2e1148b4b21681b4cec4d75b97969",
+    "zh:5950bdb23b4fcc6431562d7eba3dea37844aa4220c4da2eb898ae3e4d1b64ec4",
+    "zh:8f3d5c8d4b9d497fec36953a227f80c76d37fc8431b683a23fb1c42b9cccbf8a",
+    "zh:8f6eb5e65c047bf490ad3891efecefc488503b65898d4ee106f474697ba257d7",
+    "zh:a7040eed688316fe00379574c72bb8c47dbe2638b038bb705647cbf224de8f72",
+    "zh:e561f28df04d9e51b75f33004b7767a53c45ad96e3375d86181ba1363bffbc77",
+  ]
+}


### PR DESCRIPTION
@ahus1 I messed up the `.gitignore ` on the initial PR, so the *.hcl files weren't included as I thought. This PR addresses that and also upgrades the rhcs provider to the final 1.6.0 version.

Workflow run: https://github.com/ryanemerson/keycloak-benchmark/actions/runs/8540043303