### PR TITLE
Additional removal of reference to `TestMultiSiteLoadBalancerCheckProvider`

### DIFF
--- a/dataset/src/main/resources/META-INF/services/org.keycloak.health.LoadBalancerCheckProviderFactory
+++ b/dataset/src/main/resources/META-INF/services/org.keycloak.health.LoadBalancerCheckProviderFactory
@@ -1,1 +1,0 @@
-org.keycloak.benchmark.lb.TestMultiSiteLoadBalancerCheckProviderFactory


### PR DESCRIPTION
`TestMultiSiteLoadBalancerCheckProvider` was removed for 0.10-release (KC 22)  by https://github.com/keycloak/keycloak-benchmark/commit/657b8bc but the dataset module still references it.