### PR TITLE
Fix the handling of the `KC_OPERATOR_OLM` flag.

### DIFF
--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -232,7 +232,7 @@ tasks:
         vars:
           NAMESPACE: "{{.KC_NAMESPACE_PREFIX}}keycloak"
           ROSA_CLUSTER_NAME: "current"
-      - task: keycloak:install-keycloak-operator{{ if .KC_OPERATOR_OLM }}-olm{{ end }}
+      - task: keycloak:install-keycloak-operator{{ if eq .KC_OPERATOR_OLM "true" }}-olm{{ end }}
         vars:
           NAMESPACE: "{{.KC_NAMESPACE_PREFIX}}keycloak"
       - >


### PR DESCRIPTION
Only use the OLM task when `KC_OPERATOR_OLM` is set to `true`.