### PR TITLE
restart pods after dataset is created in rosa scaling benchmark for scheduled and on demand runs

### DIFF
--- a/.github/actions/keycloak-restart-pods/action.yml
+++ b/.github/actions/keycloak-restart-pods/action.yml
@@ -1,0 +1,16 @@
+name: Restart Keycloak Pods
+description: Restart Keycloak Pods and wait
+
+inputs:
+  project:
+    description: OpenShift project where Keycloak is running
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: restart-keycloak-pods
+      shell: bash
+      run: |
+        kubectl delete pods -n "${{ inputs.project }}" -l app=keycloak
+        kubectl wait --for=condition=Ready --timeout=1200s keycloaks.k8s.keycloak.org/keycloak -n "${{ inputs.project }}"

--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -193,6 +193,11 @@ jobs:
           ROSA_CLUSTER_NAME: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
           NAMESPACE: ${{ env.PROJECT }}
 
+      - name: Restart Keycloak Pods after dataset creation
+        uses: ./.github/actions/keycloak-restart-pods
+        with:
+          project: ${{ env.PROJECT }}
+
       - name: Create AWS EC2 instances
         id: create_aws_ec2_instances
         uses: ./.github/actions/ec2-create-instances


### PR DESCRIPTION
- I tried to do this with Keycloak CRD and annotating the restart time, but it was not working, hence fell back to using the reliable delete all pods method.