### PR TITLE
enable single aurora perf insights by default

### DIFF
--- a/provision/aws/rds/aurora_create.sh
+++ b/provision/aws/rds/aurora_create.sh
@@ -131,6 +131,8 @@ for i in $( seq ${AURORA_INSTANCES} ); do
     --db-instance-identifier "${AURORA_CLUSTER}-instance-${i}" \
     --db-instance-class ${AURORA_INSTANCE_CLASS} \
     --engine ${AURORA_ENGINE} \
+    --enable-performance-insights \
+    --performance-insights-retention-period 7 \
     --availability-zone "${AZS[$(((i - 1) % ${#AZS[@]}))]}"
 done
 


### PR DESCRIPTION
fixes #747 

starting off with only single aurora and we can propagate this to global aurora when the need comes around and we are satisfied with this feature addition.

working run: https://github.com/kami619/keycloak-benchmark/actions/runs/8710122179/job/23891308694#step:4:182 