### PR TITLE
HCP worker nodes always created in Availability Zone A. Fixes #788

### DIFF
--- a/.github/workflows/rosa-cluster-create.yml
+++ b/.github/workflows/rosa-cluster-create.yml
@@ -12,6 +12,10 @@ on:
       computeMachineType:
         description: 'Instance type for the compute nodes'
         type: string
+      availabilityZones:
+        description: 'Availability zones to deploy to'
+        default: ''
+        type: string
       replicas:
         description: 'Number of worker nodes to provision'
         type: string
@@ -67,6 +71,7 @@ jobs:
         run: ./rosa_create_cluster.sh
         working-directory: provision/aws
         env:
+          AVAILABILITY_ZONES: ${{ inputs.availabilityZones }}
           CIDR: ${{ inputs.cidr }}
           CLUSTER_NAME: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
           COMPUTE_MACHINE_TYPE: ${{ inputs.computeMachineType }}

--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -88,6 +88,7 @@ jobs:
       cidr: ${{ matrix.availabilityZone == 'a' && needs.meta.outputs.cidrA || needs.meta.outputs.cidrB }}
       clusterName: ${{ needs.meta.outputs.clusterPrefix }}-${{ matrix.availabilityZone }}
       region: ${{ needs.meta.outputs.region }}
+      availabilityZones: ${{ needs.meta.outputs.region }}${{ matrix.availabilityZone }}
     secrets: inherit
 
   deploy-keycloak:

--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -44,8 +44,11 @@ WORKSPACE=${CLUSTER_NAME}-${REGION}
 tofu workspace new ${WORKSPACE} || true
 export TF_WORKSPACE=${WORKSPACE}
 
+AVAILABILITY_ZONES=${AVAILABILITY_ZONES:-"${REGION}a"}
+
 TOFU_CMD="tofu apply -auto-approve \
   -var vpc_cidr=${CIDR} \
+  -var availability_zones=${AVAILABILITY_ZONES} \
   -var cluster_name=${CLUSTER_NAME} \
   -var region=${REGION} \
   -var subnet_cidr_prefix=28"

--- a/provision/aws/rosa_efs_create.sh
+++ b/provision/aws/rosa_efs_create.sh
@@ -90,8 +90,8 @@ EOF
 
 oc apply -f efs-csi-aws-com-cluster-csi-driver.yaml
 
-kubectl wait --for=condition=AWSEFSDriverNodeServiceControllerAvailable --timeout=600s clustercsidriver.operator.openshift.io/efs.csi.aws.com
-kubectl wait --for=condition=AWSEFSDriverControllerServiceControllerAvailable --timeout=600s clustercsidriver.operator.openshift.io/efs.csi.aws.com
+kubectl wait --for=condition=AWSEFSDriverNodeServiceControllerAvailable --timeout=900s clustercsidriver.operator.openshift.io/efs.csi.aws.com
+kubectl wait --for=condition=AWSEFSDriverControllerServiceControllerAvailable --timeout=900s clustercsidriver.operator.openshift.io/efs.csi.aws.com
 
 NODE=$(oc get nodes --selector=node-role.kubernetes.io/worker \
   -o jsonpath='{.items[0].metadata.name}')

--- a/provision/opentofu/modules/rosa/hcp/main.tf
+++ b/provision/opentofu/modules/rosa/hcp/main.tf
@@ -1,12 +1,5 @@
-data "aws_availability_zones" "available" {
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 locals {
-  azs                  = slice(data.aws_availability_zones.available.names, 0, 1)
+  azs                  = split(",", var.availability_zones)
   account_role_prefix  = var.cluster_name
   operator_role_prefix = var.cluster_name
   sts_roles            = {

--- a/provision/opentofu/modules/rosa/hcp/output.tf
+++ b/provision/opentofu/modules/rosa/hcp/output.tf
@@ -7,3 +7,8 @@ output "input_region" {
   value       = var.region
   description = "The region AWS resources created in."
 }
+
+output "input_availability_zones" {
+  value       = var.region
+  description = "The Availability Zones AWS resources created in."
+}

--- a/provision/opentofu/modules/rosa/hcp/variables.tf
+++ b/provision/opentofu/modules/rosa/hcp/variables.tf
@@ -11,6 +11,11 @@ variable "region" {
   type        = string
 }
 
+variable "availability_zones" {
+  description = "CSV of Availability Zones to create cluster in."
+  type        = string
+}
+
 variable "cluster_name" {
   description = "Name of the ROSA hosted control planes cluster to be created."
   type        = string


### PR DESCRIPTION
 Fixes #788

[Action run](https://github.com/ryanemerson/keycloak-benchmark/actions/runs/8877635506/job/24371626555). Failure is due to EFS timeout. I have added an additional commit since to further increase this.

![image](https://github.com/keycloak/keycloak-benchmark/assets/765332/65407b7b-388e-4c1c-a7a3-4f3348c9d19e)
