### PR TITLE
Use Graviton instances on AWS to save money using ARM

### DIFF
--- a/ansible/env_example.yml
+++ b/ansible/env_example.yml
@@ -2,7 +2,7 @@
 
 # Overrides for AWS EC2. Defaults located in `roles/aws_ec2/defaults/main.yml`.
 cluster_size: 2
-instance_type: t3.small
+instance_type: t4g.small
 instance_volume_size: 30
 
 # Overrides for Keycloak Benchmark. Defaults located in `roles/benchmark/defaults/main.yml`.

--- a/ansible/roles/aws_ec2/defaults/main.yml
+++ b/ansible/roles/aws_ec2/defaults/main.yml
@@ -4,9 +4,10 @@ cluster_size: 1
 
 cidr_ip: "{{ control_host_ip.stdout }}/32"
 
-ami_name: RHEL-8.8.0_HVM-20230503-x86_64-54-Hourly2-GP2
+# aws ec2 describe-images --owners self amazon --filters "Name=architecture,Values=arm64" "Name=virtualization-type,Values=hvm"  --region eu-west-1
+ami_name: RHEL-9.3.0_HVM-20231101-arm64-5-Hourly2-GP2
 
-instance_type: t3.micro
+instance_type: t4g.micro
 instance_volume_size: 20
 instance_device: /dev/sda1
 

--- a/benchmark/src/main/resources/gatling.conf
+++ b/benchmark/src/main/resources/gatling.conf
@@ -51,7 +51,9 @@ gatling {
     #maxThreadLocalCharBufferSize = 200000  # Netty's default is 16k
   }
   ssl {
-    #useOpenSsl = true                    # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
+    # Don't use OpenSSL as it is not available on Linux ARM
+    # Avoids the error message: "UnsupportedOperationException: BoringSSL is enabled in your configuration, yet it's not available for your platform linux_aarch_64."
+    useOpenSsl = false                    # if OpenSSL should be used instead of JSSE (only the latter can be debugged with -Djavax.net.debug=ssl)
     #useOpenSslFinalizers = false         # if OpenSSL contexts should be freed with Finalizer or if using RefCounted is fine
     #handshakeTimeout = 10000             # TLS handshake timeout in millis
     #useInsecureTrustManager = true       # Use an insecure TrustManager that trusts all server certificates

--- a/doc/benchmark/modules/ROOT/pages/report/rosa-benchmark-key-results.adoc
+++ b/doc/benchmark/modules/ROOT/pages/report/rosa-benchmark-key-results.adoc
@@ -145,7 +145,7 @@ See xref:run/running-benchmark-ansible.adoc[] for details.
 [source,yaml]
 ----
 cluster_size: 5
-instance_type: t3.small
+instance_type: t4g.small
 instance_volume_size: 30
 kcb_zip: ../benchmark/target/keycloak-benchmark-0.13-SNAPSHOT.zip
 kcb_heap_size: 1G

--- a/doc/benchmark/modules/ROOT/pages/run/running-benchmark-ansible.adoc
+++ b/doc/benchmark/modules/ROOT/pages/run/running-benchmark-ansible.adoc
@@ -31,7 +31,7 @@ Use the file `link:{github-files}/ansible/env_example.yml[env_example.yaml]` as 
 [source,yaml]
 ----
 cluster_size: 5
-instance_type: t3.small
+instance_type: t4g.small
 instance_volume_size: 30
 ----
 

--- a/provision/aws/rds/aurora_create_global_db.sh
+++ b/provision/aws/rds/aurora_create_global_db.sh
@@ -42,7 +42,7 @@ for (( i = 0 ; i < ${#GLOBAL_REGIONS[@]} ; i++ )) ; do
   REGION=${GLOBAL_REGIONS[i]}
   export AURORA_CLUSTER=${AURORA_GLOBAL_CLUSTER}-${REGION}
   # Aurora Global DBs must use one of the memory optimized classes
-  export AURORA_INSTANCE_CLASS="db.r5.large"
+  export AURORA_INSTANCE_CLASS="db.r6g.large"
   export AURORA_REGION=${REGION}
 
   if [ "${REGION}" != "${PRIMARY_REGION}" ]; then


### PR DESCRIPTION
I've tested the changes for the EC2 instances. I didn't test it for the Aurora global database, as we're not using it at the moment. IMHO we would test this once we start using it again.