### PR TITLE
persistent sessions load test added to the workflow

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -9,7 +9,7 @@ on:
 #   CLUSTER_PREFIX: gh-keycloak
 
 jobs:
-  cluster-deploy:
+  cluster-create-keycloak-deploy:
     name: ROSA Scheduled Create cluster
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
 
   run-functional-tests:
-    needs: cluster-deploy
+    needs: cluster-create-keycloak-deploy
     uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
@@ -31,9 +31,9 @@ jobs:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
     secrets: inherit
 
-  cluster-undeploy:
+  keycloak-undeploy:
     needs: run-scaling-benchmark
-    name: ROSA Scheduled Create cluster
+    name: Undeploy Keycloak deployment on the multi-az cluster
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
     with:
@@ -41,8 +41,8 @@ jobs:
       skipAuroraDeletion: true
     secrets: inherit
 
-  cluster-deploy-with-persistent-sessions:
-    needs: cluster-undeploy
+  keycloak-deploy-with-persistent-sessions:
+    needs: keycloak-undeploy
     name: ROSA Scheduled Create cluster with Persistent Sessions
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
@@ -53,7 +53,7 @@ jobs:
     secrets: inherit
 
   run-scaling-benchmark-with-peristent-sessions:
-    needs: cluster-deploy-with-persistent-sessions
+    needs: keycloak-deploy-with-persistent-sessions
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -9,7 +9,7 @@ on:
 #   CLUSTER_PREFIX: gh-keycloak
 
 jobs:
-  cluster:
+  cluster-deploy:
     name: ROSA Scheduled Create cluster
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
 
   run-functional-tests:
-    needs: cluster
+    needs: cluster-deploy
     uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
@@ -29,6 +29,32 @@ jobs:
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
-      skipCreateDeployment: true
-      skipDeleteProject: true
+    secrets: inherit
+
+  cluster-undeploy:
+    needs: run-scaling-benchmark
+    name: ROSA Scheduled Create cluster
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
+    with:
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      skipAuroraDeletion: true
+    secrets: inherit
+
+  cluster-deploy-with-persistent-sessions:
+    needs: cluster-undeploy
+    name: ROSA Scheduled Create cluster with Persistent Sessions
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+    uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
+    with:
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      enablePersistentSessions: true
+      createCluster: false
+    secrets: inherit
+
+  run-scaling-benchmark-with-peristent-sessions:
+    needs: cluster-deploy-with-persistent-sessions
+    uses: ./.github/workflows/rosa-scaling-benchmark.yml
+    with:
+      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
     secrets: inherit

--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -16,6 +16,10 @@ on:
       keycloakRepository:
         description: 'The repository to deploy Keycloak from. If not set nightly image is used'
         type: string
+      enablePersistentSessions:
+        description: 'To enable Persistent user and client sessions to the DB'
+        type: boolean
+        default: false
       keycloakBranch:
         description: 'The branch to deploy Keycloak from. If not set nightly image is used'
         type: string
@@ -31,6 +35,10 @@ on:
         description: 'Check to Create Cluster'
         type: boolean
         default: true
+      enablePersistentSessions:
+        description: 'To enable Persistent user and client sessions to the DB'
+        type: boolean
+        default: false
       keycloakRepository:
         description: 'The repository to deploy Keycloak from. If not set nightly image is used'
         type: string
@@ -41,6 +49,7 @@ on:
 env:
   CLUSTER_PREFIX: ${{ inputs.clusterPrefix || format('gh-{0}', github.repository_owner) }}
   REGION: ${{ inputs.region || vars.AWS_DEFAULT_REGION }}
+  KC_PERSISTENT_SESSIONS: ${{ inputs.enablePersistentSessions }}
 
 jobs:
   # Workaround required for passing env variables to reusable workflow declarations as ${{ env.* }} is not available
@@ -152,7 +161,7 @@ jobs:
           KC_CPU_REQUESTS: 6
           KC_INSTANCES: 3
           KC_DISABLE_STICKY_SESSION: true
-          KC_PERSISTENT_SESSIONS: false
+          KC_PERSISTENT_SESSIONS: ${{ env.KC_PERSISTENT_SESSIONS }}
           KC_MEMORY_REQUESTS_MB: 3000
           KC_MEMORY_LIMITS_MB: 4000
           KC_DB_POOL_INITIAL_SIZE: 30

--- a/.github/workflows/rosa-multi-az-cluster-undeploy.yml
+++ b/.github/workflows/rosa-multi-az-cluster-undeploy.yml
@@ -13,6 +13,18 @@ on:
         description: 'Skip Aurora database deletion.'
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      clusterPrefix:
+        description: 'The prefix to be used when cleaning the clusters'
+        type: string
+      region:
+        description: 'The AWS region to create both clusters in. Defaults to "vars.AWS_DEFAULT_REGION" if omitted.'
+        type: string
+      skipAuroraDeletion:
+        description: 'Skip Aurora database deletion.'
+        type: boolean
+        default: false
 
 env:
   CLUSTER_PREFIX: ${{ inputs.clusterPrefix || format('gh-{0}', github.repository_owner) }}

--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -31,16 +31,8 @@ on:
         description: 'Measurement period (seconds)'
         type: number
         default: 600
-      skipCreateDeployment:
-        description: 'Skip creating Keycloak deployment'
-        type: boolean
-        default: false
       skipCreateDataset:
         description: 'Skip creating dataset'
-        type: boolean
-        default: false
-      skipDeleteProject:
-        description: 'Skip deleting project'
         type: boolean
         default: false
 
@@ -74,16 +66,8 @@ on:
         description: 'Measurement period (seconds)'
         type: number
         default: 600
-      skipCreateDeployment:
-        description: 'Skip creating Keycloak deployment'
-        type: boolean
-        default: false
       skipCreateDataset:
         description: 'Skip creating dataset'
-        type: boolean
-        default: false
-      skipDeleteProject:
-        description: 'Skip deleting project'
         type: boolean
         default: false
 
@@ -92,15 +76,6 @@ concurrency: cluster_${{ github.event.inputs.clusterName || format('gh-{0}', git
 env:
   PROJECT_PREFIX: runner- # same as default
   PROJECT: runner-keycloak
-  KC_CPU_REQUESTS: 6
-  KC_INSTANCES: 3
-  KC_DISABLE_STICKY_SESSION: true
-  KC_PERSISTENT_SESSIONS: false
-  KC_MEMORY_REQUESTS_MB: 3000
-  KC_MEMORY_LIMITS_MB: 4000
-  KC_DB_POOL_INITIAL_SIZE: 30
-  KC_DB_POOL_MAX_SIZE: 30
-  KC_DB_POOL_MIN_SIZE: 30
   ANSIBLE_CUSTOM_VARS_ARG: '-e @env_rosa_benchmark.yml'
 
 jobs:
@@ -148,21 +123,6 @@ jobs:
           ./mvnw -B clean package -DskipTests -pl benchmark
           tar xfvz benchmark/target/keycloak-benchmark-*.tar.gz
           mv keycloak-benchmark-* keycloak-benchmark
-
-      - name: Allow cluster to scale
-        if: ${{ !inputs.skipCreateDeployment }}
-        run: rosa edit machinepool -c ${{ inputs.clusterName }} --min-replicas 3 scaling
-
-      - name: Create Keycloak deployment
-        if: ${{ !inputs.skipCreateDeployment }}
-        uses: ./.github/actions/keycloak-create-deployment
-        with:
-          projectPrefix: ${{ env.PROJECT_PREFIX }}
-          disableStickySessions: ${{ !env.KC_DISABLE_STICKY_SESSION }}
-          replicas: ${{ env.KC_INSTANCES }}
-          podCpuRequests: ${{ env.KC_CPU_REQUESTS }}
-          podMemoryRequests: ${{ env.KC_MEMORY_REQUESTS_MB }}
-          podMemoryLimit: ${{ env.KC_MEMORY_LIMITS_MB }}
 
       - name: Get URLs
         uses: ./.github/actions/get-keycloak-url
@@ -346,25 +306,30 @@ jobs:
         with:
           createReportFile: false
 
+      - name: Generate timestamp for archive name
+        run: |
+          cur_epoch_time=$(date +%s)
+          echo "ARCHIVE_EPOCH=$cur_epoch_time" >> $GITHUB_ENV
+
       - name: Archive Gatling reports
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: gatling-results
+          name: gatling-results-${{ env.ARCHIVE_EPOCH }}
           path: ansible/files/benchmark/*/results
           retention-days: 5
 
       - name: Archive Summary
         uses: actions/upload-artifact@v4
         with:
-          name: summary
+          name: summary-${{ env.ARCHIVE_EPOCH }}
           path: ansible/files/benchmark/*/results/*/js/stats.json
           retention-days: 5
 
       - name: Archive Calculated Metrics summary
         uses: actions/upload-artifact@v4
         with:
-          name: Calculated environment conclusion
+          name: final-report-json-${{ env.ARCHIVE_EPOCH }}
           path: |
             result-*.json
           retention-days: 5
@@ -374,16 +339,6 @@ jobs:
         uses: ./.github/actions/ec2-delete-instances
         with:
           region: ${{ inputs.region }}
-
-      - name: Delete Keycloak deployment
-        if: ${{ (success() || failure()) && !inputs.skipDeleteProject }}
-        uses: ./.github/actions/keycloak-delete-deployment
-        with:
-          project: ${{ env.PROJECT }}
-
-      - name: Scale down the cluster
-        if: ${{ (success() || failure()) && !inputs.skipDeleteProject }}
-        run: rosa edit machinepool -c ${{ inputs.clusterName }} --min-replicas 0 scaling
 
   archive:
     name: Commit results to Git repository
@@ -401,7 +356,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: Calculated environment conclusion
+          name: final-report-json-${{ env.ARCHIVE_EPOCH }}
 
       - name: Commit result-summary
         shell: bash

--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -75,7 +75,8 @@ fi
 
 cd ${SCRIPT_DIR}
 ./rosa_oc_login.sh
-./rosa_efs_create.sh
+# EFS creation disabled due to https://issues.redhat.com/browse/CLOUDDST-22629
+# ./rosa_efs_create.sh
 ../infinispan/install_operator.sh
 
 # cryostat operator depends on certmanager operator

--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -26,47 +26,53 @@ requiredEnv AWS_ACCOUNT CLUSTER_NAME REGION CIDR
 
 export CLUSTER_NAME=${CLUSTER_NAME:-$(whoami)}
 
-echo "Verifying ROSA prerequisites."
-echo "Check if AWS CLI is installed."; aws --version
-echo "Check if ROSA CLI is installed."; rosa version
-echo "Check if ELB service role is enabled."
-if ! aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" --no-cli-pager; then
-  aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"
+echo "Checking if cluster ${CLUSTER_NAME} already exists."
+if rosa describe cluster --cluster="${CLUSTER_NAME}"; then
+  echo "Cluster ${CLUSTER_NAME} already exists."
+else
+  echo "Verifying ROSA prerequisites."
+  echo "Check if AWS CLI is installed."; aws --version
+  echo "Check if ROSA CLI is installed."; rosa version
+  echo "Check if ELB service role is enabled."
+  if ! aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" --no-cli-pager; then
+    aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"
+  fi
+  rosa whoami
+  rosa verify quota
+
+  echo "Installing ROSA cluster ${CLUSTER_NAME}"
+
+  cd ${SCRIPT_DIR}/../opentofu/modules/rosa/hcp
+  tofu init
+  WORKSPACE=${CLUSTER_NAME}-${REGION}
+  tofu workspace new ${WORKSPACE} || true
+  export TF_WORKSPACE=${WORKSPACE}
+
+  AVAILABILITY_ZONES=${AVAILABILITY_ZONES:-"${REGION}a"}
+
+  TOFU_CMD="tofu apply -auto-approve \
+    -var vpc_cidr=${CIDR} \
+    -var availability_zones=${AVAILABILITY_ZONES} \
+    -var cluster_name=${CLUSTER_NAME} \
+    -var region=${REGION} \
+    -var subnet_cidr_prefix=28"
+
+  if [ -n "${COMPUTE_MACHINE_TYPE}" ]; then
+    TOFU_CMD+=" -var instance_type=${COMPUTE_MACHINE_TYPE}"
+  fi
+
+  if [ -n "${VERSION}" ]; then
+    TOFU_CMD+=" -var openshift_version=${VERSION}"
+  fi
+
+  if [ -n "${REPLICAS}" ]; then
+    TOFU_CMD+=" -var replicas=${REPLICAS}"
+  fi
+
+  echo ${TOFU_CMD}
+  ${TOFU_CMD}
+
 fi
-rosa whoami
-rosa verify quota
-
-echo "Installing ROSA cluster ${CLUSTER_NAME}"
-
-cd ${SCRIPT_DIR}/../opentofu/modules/rosa/hcp
-tofu init
-WORKSPACE=${CLUSTER_NAME}-${REGION}
-tofu workspace new ${WORKSPACE} || true
-export TF_WORKSPACE=${WORKSPACE}
-
-AVAILABILITY_ZONES=${AVAILABILITY_ZONES:-"${REGION}a"}
-
-TOFU_CMD="tofu apply -auto-approve \
-  -var vpc_cidr=${CIDR} \
-  -var availability_zones=${AVAILABILITY_ZONES} \
-  -var cluster_name=${CLUSTER_NAME} \
-  -var region=${REGION} \
-  -var subnet_cidr_prefix=28"
-
-if [ -n "${COMPUTE_MACHINE_TYPE}" ]; then
-  TOFU_CMD+=" -var instance_type=${COMPUTE_MACHINE_TYPE}"
-fi
-
-if [ -n "${VERSION}" ]; then
-  TOFU_CMD+=" -var openshift_version=${VERSION}"
-fi
-
-if [ -n "${REPLICAS}" ]; then
-  TOFU_CMD+=" -var replicas=${REPLICAS}"
-fi
-
-echo ${TOFU_CMD}
-${TOFU_CMD}
 
 SCALING_MACHINE_POOL=$(rosa list machinepools -c "${CLUSTER_NAME}" -o json | jq -r '.[] | select(.id == "scaling") | .id')
 if [[ "${SCALING_MACHINE_POOL}" != "scaling" ]]; then

--- a/provision/common/Taskfile.yaml
+++ b/provision/common/Taskfile.yaml
@@ -95,6 +95,7 @@ tasks:
           '. + { "numOfPods": ($num_of_pods|tonumber), "cpuRequestsPerPod": ($cpu_requests_per_pod|tonumber),
                              "cpuLimitsPerPod": (if ($cpu_limits_per_pod | length) == 0 then null else ($cpu_limits_per_pod | tonumber?) end),
                              "stickySessionDisabled": ($sticky_sessions),
+                             "persistentSessionsEnabled": ($persistent_sessions),
                              "memRequestsPerPod": ($mem_req_per_pod|tonumber),
                              "memLimitPerPod": ($mem_limit_per_pod|tonumber),
                              "dbPool": {

--- a/provision/minikube/keycloak/templates/sqlpad.yaml
+++ b/provision/minikube/keycloak/templates/sqlpad.yaml
@@ -38,7 +38,7 @@ spec:
               value: /etc/sqlpad/seed-data
 {{ if or (eq .Values.database "postgres") (eq .Values.database "postgres+infinispan" ) }}
             - name: SQLPAD_CONNECTIONS__pgdemo__name
-              value: PostgresSQL Keycloak
+              value: PostgreSQL Keycloak
             - name: SQLPAD_CONNECTIONS__pgdemo__port
               value: '5432'
             - name: SQLPAD_CONNECTIONS__pgdemo__host


### PR DESCRIPTION
Fixes #785 

- [x] Updated the Multi-AZ Create workflow to suit our current needs
- [x] Trimmed the ROSA Scaling Benchmark workflow to only perform dataset creation and benchmark and reporting
- [x] Updated the scheduled workflow to accommodate two deployments and benchmarks
- [x] Added filterable fields to Horreum report based on the deployment type (Additional work would be needed here to filter the reports in Horreum)
- [x] Local tests 

Note: this will allow the test results from persistent sessions to goto horreum now, but with some additional work @andyuk1986 confirmed we would be able to filter them out based on the deployment context we are updating the upcoming horreum report schema changes.