### PR TITLE
Do not create dataset twice

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -57,4 +57,5 @@ jobs:
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
+      skipCreateDataset: true
     secrets: inherit


### PR DESCRIPTION
Since we already created the dataset when running regular benchmark, we do not need to create it again for persistent sessions. 