### PR TITLE
add a delete namesapce workflow for multi-az deploy and use it in scheduled CI workflow

### DIFF
--- a/.github/workflows/oc-namespace-delete.yml
+++ b/.github/workflows/oc-namespace-delete.yml
@@ -1,0 +1,51 @@
+name: Keycloak - Delete namespace on OpenShift Multi-AZ clusters
+
+on:
+  workflow_dispatch:
+    inputs:
+      clusterPrefix:
+        description: OpenShift cluster prefix for a multi-AZ deployment
+        required: true
+      project:
+        description: OpenShift project where Keycloak is running
+        required: true
+
+jobs:
+  run:
+    name: Delete Keycloak Namespaces
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup ROSA CLI
+        uses: ./.github/actions/rosa-cli-setup
+        with:
+          aws-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-default-region: ${{ vars.AWS_DEFAULT_REGION }}
+          rosa-token: ${{ secrets.ROSA_TOKEN }}
+
+      - name: Login to OpenShift cluster A
+        uses: ./.github/actions/oc-keycloak-login
+        with:
+          clusterName: ${{ inputs.clusterPrefix }}-a
+
+      - id: delete-openshift-namespace-cluster-a
+        shell: bash
+        working-directory: provision/openshift
+        env:
+          PROJECT: ${{ inputs.project }}
+        run: ./delete-namespace.sh
+
+      - name: Login to OpenShift cluster B
+        uses: ./.github/actions/oc-keycloak-login
+        with:
+          clusterName: ${{ inputs.clusterPrefix }}-b
+
+      - id: delete-openshift-namespace-cluster-b
+        shell: bash
+        working-directory: provision/openshift
+        env:
+          PROJECT: ${{ inputs.project }}
+        run: ./delete-namespace.sh

--- a/provision/openshift/delete-namespace.sh
+++ b/provision/openshift/delete-namespace.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
+
+: ${PROJECT:="runner-keycloak"}
+
+echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') Deleting the ${PROJECT} namespace \033[0m"
+
+oc delete namespace ${PROJECT}
+
+while oc get project ${PROJECT} &> /dev/null; do
+  echo "Waiting for namespace ${PROJECT} to be deleted..."
+  sleep 2
+done
+
+echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') ${PROJECT} namespace is now deleted successfully.\033[0m"


### PR DESCRIPTION
fixes #844 

A working workflow run - https://github.com/kami619/keycloak-benchmark/actions/runs/9403463979/job/25900073424

Another working run with a custom project name `kamesh-keycloak` - https://github.com/kami619/keycloak-benchmark/actions/runs/9403617989/job/25900583038