### PR TITLE
Fix rosa failure to edit scaling machinepool

### DIFF
--- a/.github/actions/rosa-cli-setup/action.yml
+++ b/.github/actions/rosa-cli-setup/action.yml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: |
         cd /usr/local/bin/
-        curl https://mirror.openshift.com/pub/openshift-v4/clients/rosa/1.2.38/rosa-linux.tar.gz | tar xz
+        curl https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz | tar xz
 
     - id: rosa-cli-login
       name: Login ROSA CLI


### PR DESCRIPTION

Closes #821 

ROSA [v1.2.40](https://github.com/openshift/rosa/releases/tag/v1.2.40) is now available, so we should be able to use the latest release once again.