### PR TITLE
Enable protostream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
   <properties>
     <keycloak.version>999.0.0-SNAPSHOT</keycloak.version>
+    <infinispan.version>15.0.4.Final</infinispan.version>
     <junit5.version>5.10.1</junit5.version>
     <httpclient.version>4.5.14</httpclient.version>
     <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>
@@ -86,6 +87,12 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>${httpclient.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-client-rest</artifactId>
+        <version>${infinispan.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -141,6 +141,8 @@ spec:
       owners: {{ $config.owners | default $.Values.cacheDefaults.owners | quote }}
       statistics: "true"
       remoteTimeout: {{ $config.remoteTimeout | default $.Values.cacheDefaults.remoteTimeout }}
+      encoding:
+        media-type: "application/x-protostream"
       locking:
         acquireTimeout: {{ $config.lockTimeout | default $.Values.cacheDefaults.lockTimeout }}
       {{- if and $config.memory $config.memory.maxCount }}

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/pom.xml
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/pom.xml
@@ -89,6 +89,16 @@
             <artifactId>openshift-client</artifactId>
             <version>${fabric8.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-rest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-infinispan</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/LoginLogoutTest.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/LoginLogoutTest.java
@@ -22,7 +22,6 @@ public class LoginLogoutTest extends AbstractCrossDCTest {
     protected static final Logger LOG = Logger.getLogger(LoginLogoutTest.class);
 
     @Test
-    @Disabled
     public void loginLogoutTest() throws URISyntaxException, IOException, InterruptedException {
         //Login and exchange code in DC1
         String code = LOAD_BALANCER_KEYCLOAK.usernamePasswordLogin(REALM_NAME, USERNAME, MAIN_PASSWORD, CLIENTID);

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/DatacenterInfo.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/DatacenterInfo.java
@@ -57,7 +57,7 @@ public class DatacenterInfo implements AutoCloseable {
         this.loadbalancerURL = getRouteHost("keycloak");
 
         this.keycloak = new KeycloakClient(httpClient, keycloakServerURL, activePassive);
-        this.infinispan = new ExternalInfinispanClient(httpClient, infinispanServerURL, AbstractCrossDCTest.ISPN_USERNAME, AbstractCrossDCTest.MAIN_PASSWORD, keycloakServerURL);
+        this.infinispan = new ExternalInfinispanClient(infinispanServerURL, AbstractCrossDCTest.ISPN_USERNAME, AbstractCrossDCTest.MAIN_PASSWORD);
     }
 
     private String getRouteHost(String app) {
@@ -75,6 +75,7 @@ public class DatacenterInfo implements AutoCloseable {
 
     @Override
     public void close() {
+        infinispan.close();
         this.oc.close();
     }
 

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/InfinispanClient.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/InfinispanClient.java
@@ -24,4 +24,8 @@ public interface InfinispanClient<T extends InfinispanClient.Cache> {
     }
 
     T cache(String name);
+
+    default void close() {
+
+    }
 }


### PR DESCRIPTION
* Enables protostream encoding in the external Infinispan
* Changes the testsuite to use the Hot Rod client

Closes #628

I have the following error with status code 500. I haven't figured out where they come from. I couldn't find any exceptions in the pod's log. 

```
[ERROR]   EntityReplicationTest.keycloakEntityReplicationOverCacheTest:25 » InternalServerError HTTP 500 Internal Server Error
[ERROR]   SessionExpirationTest.sessionExpirationTest:19 » InternalServerError HTTP 500 Internal Server Error
```

We probably need to fork the `main` branch before merging this one. The forked branch will keep compatibility with jboss-marshalling and KC25. 