### PR TITLE
Enable External Infinispan Feature

### DIFF
--- a/.github/actions/keycloak-create-deployment/action.yml
+++ b/.github/actions/keycloak-create-deployment/action.yml
@@ -15,6 +15,9 @@ inputs:
   enablePersistentSessions:
     description: 'Enable persistent sessions to DB'
     default: 'false'
+  enableExternalInfinispanFeature:
+    description: 'To enable the external Infinispan feature. It disables the embedded caches and only uses the remote caches.'
+    default: 'false'
   image:
     description: 'Keycloak Image'
   podMemoryRequests:
@@ -53,6 +56,7 @@ runs:
         KC_INSTANCES: ${{ inputs.replicas }}
         KC_DISABLE_STICKY_SESSION: ${{ inputs.disableStickySessions }}
         KC_PERSISTENT_SESSIONS: ${{ inputs.enablePersistentSessions }}
+        KC_EXTERNAL_INFINISPAN: ${{ inputs.enableExternalInfinispanFeature }}
         KC_CONTAINER_IMAGE: ${{ inputs.image }}
         KC_MEMORY_REQUESTS_MB: ${{ inputs.podMemoryRequests }}
         KC_MEMORY_LIMITS_MB: ${{ inputs.podMemoryLimit }}

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -72,8 +72,39 @@ jobs:
       skipAuroraDeletion: true
     secrets: inherit
 
-  keycloak-deploy-active-active:
+  keycloak-deploy-with-external-infinispan:
     needs: keycloak-undeploy-with-persistent-sessions
+    name: ROSA Scheduled Create cluster with External Infinispan Feature
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+    uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
+    with:
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      enableExternalInfinispanFeature: true
+      createCluster: false
+    secrets: inherit
+
+  run-scaling-benchmark-with-external-infinispan:
+    needs: keycloak-deploy-with-external-infinispan
+    name: Scaling Benchmark with External Infinispan Feature
+    uses: ./.github/workflows/rosa-scaling-benchmark.yml
+    with:
+      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
+      skipCreateDataset: true
+      outputArchiveSuffix: 'external-infinispan'
+    secrets: inherit
+
+  keycloak-undeploy-with-external-infinispan:
+    needs: run-scaling-benchmark-with-external-infinispan
+    name: Undeploy Keycloak deployment on the multi-az cluster
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
+    with:
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      skipAuroraDeletion: true
+    secrets: inherit
+
+  keycloak-deploy-active-active:
+    needs: keycloak-undeploy-with-external-infinispan
     name: ROSA Scheduled Create Active/Active cluster with Persistent Sessions
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml

--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -24,6 +24,10 @@ on:
         description: 'To enable Persistent user and client sessions to the DB'
         type: boolean
         default: false
+      enableExternalInfinispanFeature:
+        description: 'To enable the external Infinispan feature. It disables the embedded caches and only uses the remote caches.'
+        type: boolean
+        default: false
       keycloakBranch:
         description: 'The branch to deploy Keycloak from. If not set nightly image is used'
         type: string
@@ -50,6 +54,10 @@ on:
         description: 'To enable Persistent user and client sessions to the DB'
         type: boolean
         default: false
+      enableExternalInfinispanFeature:
+        description: 'To enable the external Infinispan feature. It disables the embedded caches and only uses the remote caches.'
+        type: boolean
+        default: false
       keycloakBranch:
         description: 'The branch to deploy Keycloak from. If not set nightly image is used'
         type: string
@@ -58,6 +66,7 @@ env:
   CLUSTER_PREFIX: ${{ inputs.clusterPrefix || format('gh-{0}', github.repository_owner) }}
   REGION: ${{ inputs.region || vars.AWS_DEFAULT_REGION }}
   KC_PERSISTENT_SESSIONS: ${{ inputs.enablePersistentSessions }}
+  KC_EXTERNAL_INFINISPAN: ${{ inputs.enableExternalInfinispanFeature }}
 
 jobs:
   # Workaround required for passing env variables to reusable workflow declarations as ${{ env.* }} is not available
@@ -178,6 +187,7 @@ jobs:
           KC_INSTANCES: 3
           KC_DISABLE_STICKY_SESSION: true
           KC_PERSISTENT_SESSIONS: ${{ env.KC_PERSISTENT_SESSIONS }}
+          KC_EXTERNAL_INFINISPAN: ${{ env.KC_EXTERNAL_INFINISPAN }}
           KC_MEMORY_REQUESTS_MB: 3000
           KC_MEMORY_LIMITS_MB: 4000
           KC_DB_POOL_INITIAL_SIZE: 30
@@ -217,6 +227,7 @@ jobs:
           KC_INSTANCES: 3
           KC_DISABLE_STICKY_SESSION: true
           KC_PERSISTENT_SESSIONS: ${{ env.KC_PERSISTENT_SESSIONS }}
+          KC_EXTERNAL_INFINISPAN: ${{ env.KC_EXTERNAL_INFINISPAN }}
           KC_MEMORY_REQUESTS_MB: 3000
           KC_MEMORY_LIMITS_MB: 4000
           KC_DB_POOL_INITIAL_SIZE: 30

--- a/provision/common/Taskfile.yaml
+++ b/provision/common/Taskfile.yaml
@@ -25,6 +25,7 @@ vars:
   KC_REMOTE_STORE_PORT: '{{default "11222" .KC_REMOTE_STORE_PORT}}'
   KC_DISABLE_STICKY_SESSION: '{{default "false" .KC_DISABLE_STICKY_SESSION}}'
   KC_PERSISTENT_SESSIONS: '{{default "false" .KC_PERSISTENT_SESSIONS}}'
+  KC_EXTERNAL_INFINISPAN: '{{default "false" .KC_EXTERNAL_INFINISPAN}}'
   MULTI_AZ: '{{default "false" .MULTI_AZ}}'
   ENV_DATA_JSON_PATH: "{{.ROOT_DIR}}/../environment_data.json"
   KC_REPOSITORY: '{{default "" .KC_REPOSITORY}}'
@@ -72,6 +73,7 @@ tasks:
       - echo {{.KC_REMOTE_STORE_PORT}} > .task/var-KC_REMOTE_STORE_PORT
       - echo {{.KC_DISABLE_STICKY_SESSION}} > .task/var-KC_DISABLE_STICKY_SESSION
       - echo {{.KC_PERSISTENT_SESSIONS}} > .task/var-KC_PERSISTENT_SESSIONS
+      - echo {{.KC_EXTERNAL_INFINISPAN}} > .task/var-KC_EXTERNAL_INFINISPAN
       - echo {{.KC_HOSTNAME_OVERRIDE}} > .task/var-KC_HOSTNAME_OVERRIDE
       - echo {{.KC_HEALTH_HOSTNAME}} > .task/var-KC_HEALTH_HOSTNAME
       - |
@@ -80,6 +82,7 @@ tasks:
           --arg num_of_pods "{{ .KC_INSTANCES }}" \
           --argjson sticky_sessions "{{ .KC_DISABLE_STICKY_SESSION }}" \
           --argjson persistent_sessions "{{ .KC_PERSISTENT_SESSIONS }}" \
+          --argjson external_infinispan "{{ .KC_EXTERNAL_INFINISPAN }}" \
           --arg mem_req_per_pod "{{ .KC_MEMORY_REQUESTS_MB }}" \
           --arg mem_limit_per_pod "{{ .KC_MEMORY_LIMITS_MB }}" \
           --arg db_pool_init "{{ .KC_DB_POOL_INITIAL_SIZE }}" \
@@ -95,6 +98,7 @@ tasks:
           '. + { "numOfPods": ($num_of_pods|tonumber), "cpuRequestsPerPod": ($cpu_requests_per_pod|tonumber),
                              "cpuLimitsPerPod": (if ($cpu_limits_per_pod | length) == 0 then null else ($cpu_limits_per_pod | tonumber?) end),
                              "stickySessionDisabled": ($sticky_sessions),
+                             "externalInfinispanFeatureEnabled": ($external_infinispan),
                              "persistentSessionsEnabled": ($persistent_sessions),
                              "memRequestsPerPod": ($mem_req_per_pod|tonumber),
                              "memLimitPerPod": ($mem_limit_per_pod|tonumber),
@@ -139,6 +143,7 @@ tasks:
       - test "{{.KC_REMOTE_STORE_PORT}}" == "$(cat .task/var-KC_REMOTE_STORE_PORT)"
       - test "{{.KC_DISABLE_STICKY_SESSION}}" == "$(cat .task/var-KC_DISABLE_STICKY_SESSION)"
       - test "{{.KC_PERSISTENT_SESSIONS}}" == "$(cat .task/var-KC_PERSISTENT_SESSIONS)"
+      - test "{{.KC_EXTERNAL_INFINISPAN}}" == "$(cat .task/var-KC_EXTERNAL_INFINISPAN)"
       - test "{{.KC_HOSTNAME_OVERRIDE}}" == "$(cat .task/var-KC_HOSTNAME_OVERRIDE)"
       - test "{{.KC_HEALTH_HOSTNAME}}" == "$(cat .task/var-KC_HEALTH_HOSTNAME)"
 

--- a/provision/keycloak-tasks/Taskfile.yaml
+++ b/provision/keycloak-tasks/Taskfile.yaml
@@ -53,6 +53,7 @@ vars:
   KC_REMOTE_STORE_PORT: '{{default "11222" .KC_REMOTE_STORE_PORT}}'
   KC_DISABLE_STICKY_SESSION: '{{default "false" .KC_DISABLE_STICKY_SESSION}}'
   KC_PERSISTENT_SESSIONS: '{{default "false" .KC_PERSISTENT_SESSIONS}}'
+  KC_EXTERNAL_INFINISPAN: '{{default "false" .KC_EXTERNAL_INFINISPAN}}'
 
 tasks:
   default:

--- a/provision/keycloak-tasks/Utils.yaml
+++ b/provision/keycloak-tasks/Utils.yaml
@@ -256,6 +256,7 @@ tasks:
         --set keycloakAdminPassword="{{.KC_ADMIN_PASSWORD}}"
         --set disableIngressStickySession={{ .KC_DISABLE_STICKY_SESSION }}
         --set persistentSessions={{ .KC_PERSISTENT_SESSIONS }}
+        --set externalInfinispan={{ .KC_EXTERNAL_INFINISPAN }}
         --set nodePortsEnabled=false
         ../minikube/keycloak
     preconditions:

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -60,6 +60,9 @@ spec:
 {{- if .Values.persistentSessions }}
       - persistent-user-sessions
 {{- end }}
+{{- if .Values.externalInfinispan }}
+      - remote-cache
+{{- end }}
 {{- if .Values.infinispan.customConfig }}
   # tag::keycloak-ispn[]
   cache:

--- a/provision/minikube/keycloak/values.yaml
+++ b/provision/minikube/keycloak/values.yaml
@@ -41,6 +41,7 @@ disableIngressStickySession: false
 jvmDebug: true
 predefinedAdmin: true
 persistentSessions: false
+externalInfinispan: false
 infinispan:
   jgroupsTls: false
   customConfig: false

--- a/provision/openshift/Taskfile.yaml
+++ b/provision/openshift/Taskfile.yaml
@@ -274,6 +274,7 @@ tasks:
         --set keycloakAdminPassword="{{.KC_ADMIN_PASSWORD}}"
         --set disableIngressStickySession={{ .KC_DISABLE_STICKY_SESSION }}
         --set persistentSessions={{ .KC_PERSISTENT_SESSIONS }}
+        --set externalInfinispan={{ .KC_EXTERNAL_INFINISPAN }}
         --set nodePortsEnabled=false
         ../minikube/keycloak
       - >


### PR DESCRIPTION
* New option to enable external infinispan feature (disabled by default)
* Added to the nightly runs to get some numbers

It has been a while since I looked at those GH action files. Please double-check if I did it right. 
I tested a deployment with `KC_EXTERNAL_INFINISPAN=true` and confirmed no embedded caches were present in Keycloak Servers. 