### PR TITLE
Active active test fix

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -115,6 +115,14 @@ jobs:
       activeActive: true
     secrets: inherit
 
+  run-functional-tests-active-active:
+    needs: keycloak-deploy-active-active
+    uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
+    with:
+      activeActive: true
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+    secrets: inherit
+
   run-scaling-benchmark-active-active:
     needs: keycloak-deploy-active-active
     uses: ./.github/workflows/rosa-scaling-benchmark.yml

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -124,7 +124,7 @@ jobs:
     secrets: inherit
 
   run-scaling-benchmark-active-active:
-    needs: keycloak-deploy-active-active
+    needs: run-functional-tests-active-active
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a

--- a/doc/kubernetes/modules/ROOT/pages/running/loadbalancing.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/running/loadbalancing.adoc
@@ -28,7 +28,8 @@ image::accelerator/accelerator-multi-az.dio.svg[]
 
 An AWS Network Load Balancer (NLB) is created on both ROSA clusters in order to make the Keycloak
 pods available as Endpoints to an AWS Global Accelerator instance. Each cluster endpoint is assigned a weight of
-50 to ensure that accelerator traffic is routed equally to both availability-zones when both clusters are healthy.
+128 (half of the maximum weight 255) to ensure that accelerator traffic is routed equally to both availability-zones
+when both clusters are healthy.
 
 == Prerequisites
 
@@ -196,12 +197,12 @@ CLUSTER_2_ENDPOINT_ARN=$(aws elbv2 describe-load-balancers \
 ENDPOINTS='[
   {
     "EndpointId": "'${CLUSTER_1_ENDPOINT_ARN}'",
-    "Weight": 50,
+    "Weight": 128,
     "ClientIPPreservationEnabled": false
   },
   {
     "EndpointId": "'${CLUSTER_2_ENDPOINT_ARN}'",
-    "Weight": 50,
+    "Weight": 128,
     "ClientIPPreservationEnabled": false
   }
 ]'
@@ -226,13 +227,13 @@ aws globalaccelerator create-endpoint-group \
         "EndpointDescriptions": [
             {
                 "EndpointId": "arn:aws:elasticloadbalancing:eu-west-1:606671647913:loadbalancer/net/abab80a363ce8479ea9c4349d116bce2/6b65e8b4272fa4b5",
-                "Weight": 50,
+                "Weight": 128,
                 "HealthState": "HEALTHY",
                 "ClientIPPreservationEnabled": false
             },
             {
                 "EndpointId": "arn:aws:elasticloadbalancing:eu-west-1:606671647913:loadbalancer/net/a1c76566e3c334e4ab7b762d9f8dcbcf/985941f9c8d108d4",
-                "Weight": 50,
+                "Weight": 128,
                 "HealthState": "HEALTHY",
                 "ClientIPPreservationEnabled": false
             }

--- a/doc/kubernetes/modules/ROOT/pages/running/take-active-site-offline.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/running/take-active-site-offline.adoc
@@ -33,13 +33,13 @@ include::partial$accelerator-endpoint-group.adoc[]
             "EndpointDescriptions": [
                 {
                     "EndpointId": "arn:aws:elasticloadbalancing:eu-west-1:606671647913:loadbalancer/net/a49e56e51e16843b9a3bc686327c907b/9b786f80ed4eba3d",
-                    "Weight": 50,
+                    "Weight": 128,
                     "HealthState": "HEALTHY",
                     "ClientIPPreservationEnabled": false
                 },
                 {
                     "EndpointId": "arn:aws:elasticloadbalancing:eu-west-1:606671647913:loadbalancer/net/a3c75f239541c4a6e9c48cf8d48d602f/5ba333e87019ccf0",
-                    "Weight": 50,
+                    "Weight": 128,
                     "HealthState": "HEALTHY",
                     "ClientIPPreservationEnabled": false
                 }
@@ -66,7 +66,7 @@ aws globalaccelerator update-endpoint-group \
   [
     {
         "EndpointId": "arn:aws:elasticloadbalancing:eu-west-1:606671647913:loadbalancer/net/a49e56e51e16843b9a3bc686327c907b/9b786f80ed4eba3d",
-        "Weight": 50,
+        "Weight": 128,
         "ClientIPPreservationEnabled": false
     }
   ]

--- a/provision/infinispan/ispn-helm/templates/infinispan-alerts.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan-alerts.yaml
@@ -18,6 +18,10 @@ metadata:
 spec:
   route:
     receiver: default
+    groupBy:
+      - accelerator
+    groupInterval: 90s
+    groupWait: 0s
     matchers:
       - matchType: =
         name: alertname

--- a/provision/openshift/cluster-monitoring-config.yaml
+++ b/provision/openshift/cluster-monitoring-config.yaml
@@ -8,3 +8,4 @@ data:
     alertmanager:
       enabled: true
       enableAlertmanagerConfig: true
+      logLevel: debug

--- a/provision/opentofu/modules/aws/accelerator/main.tf
+++ b/provision/opentofu/modules/aws/accelerator/main.tf
@@ -30,11 +30,11 @@ module "global_accelerator" {
           {
             client_ip_preservation_enabled = false
             endpoint_id                    = data.aws_lb.site_a.arn
-            weight                         = 50
+            weight                         = 128
           }, {
             client_ip_preservation_enabled = false
             endpoint_id                    = data.aws_lb.site_b.arn
-            weight                         = 50
+            weight                         = 128
           }
         ]
       }

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/pom.xml
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/pom.xml
@@ -18,6 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aws.java.sdk.version>2.20.43</aws.java.sdk.version>
         <fabric8.version>6.13.0</fabric8.version>
+        <jsonpath.version>2.9.0</jsonpath.version>
     </properties>
 
     <dependencies>
@@ -98,6 +99,11 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-model-infinispan</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${jsonpath.version}</version>
         </dependency>
     </dependencies>
 

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/AbstractCrossDCTest.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/AbstractCrossDCTest.java
@@ -60,7 +60,8 @@ public abstract class AbstractCrossDCTest {
     }
 
     @BeforeEach
-    public void setUpTestEnvironment() throws UnknownHostException {
+    public void setUpTestEnvironment() throws URISyntaxException, IOException, InterruptedException, UnknownHostException {
+        failbackLoadBalancers();
         assertTrue(DC_1.kc().isActive(LOAD_BALANCER_KEYCLOAK));
 
         Keycloak adminClient = DC_1.kc().adminClient();

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
@@ -207,7 +207,7 @@ public class AWSClient {
                .map(elb -> EndpointConfiguration.builder()
                      .clientIPPreservationEnabled(false)
                      .endpointId(elb)
-                     .weight(50)
+                     .weight(128)
                      .build()
                ).toList();
 

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
@@ -1,6 +1,14 @@
 package org.keycloak.benchmark.crossdc.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -12,7 +20,10 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.DescribeAlarmsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 import software.amazon.awssdk.services.cloudwatch.model.StateValue;
+import software.amazon.awssdk.services.cloudwatch.model.Statistic;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.LoadBalancer;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.LoadBalancerTypeEnum;
@@ -33,22 +44,53 @@ public class AWSClient {
 
    private static final Logger LOG = Logger.getLogger(AWSClient.class);
 
+   public static int getLambdaInvocationCount(String name, String region, Instant startTime) {
+      try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+           CloudWatchClient cloudWatch = CloudWatchClient.builder()
+                 .region(Region.of(region))
+                 .httpClient(httpClient)
+                 .build()) {
+
+         var metricDataRsp = cloudWatch.getMetricData(mdq -> mdq.metricDataQueries(
+                           q -> q.id("invocations")
+                                 .metricStat(
+                                       ms -> ms.metric(m ->
+                                                   m.namespace("AWS/Lambda")
+                                                         .metricName("Invocations")
+                                                         .dimensions(d -> d.name("FunctionName").value(name))
+                                             )
+                                             .period(1)
+                                             .stat(Statistic.SUM.toString())
+                                 )
+                     )
+                     .startTime(startTime)
+                     .endTime(Instant.now())
+         );
+
+         var metricsDataResults = metricDataRsp.metricDataResults();
+         assertEquals(metricsDataResults.size(), 1);
+         var metrics = metricsDataResults.get(0).values();
+         System.out.println(metrics);
+         return metrics.isEmpty() ? 0 : metrics.get(0).intValue();
+      }
+   }
+
    public static String getHealthCheckId(String domainName) {
       try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
-          Route53Client route53 = Route53Client.builder().httpClient(httpClient).build()) {
-          for (HealthCheck hc : route53.listHealthChecks(SdkBuilder::build).healthChecks()) {
-             if (domainName.equals(hc.healthCheckConfig().fullyQualifiedDomainName())) {
-                LOG.infof("Found Route53 HealthCheck '%s' for Domain='%s'", hc.id(), domainName);
-                return hc.id();
-             }
-          }
+           Route53Client route53 = Route53Client.builder().httpClient(httpClient).build()) {
+         for (HealthCheck hc : route53.listHealthChecks(SdkBuilder::build).healthChecks()) {
+            if (domainName.equals(hc.healthCheckConfig().fullyQualifiedDomainName())) {
+               LOG.infof("Found Route53 HealthCheck '%s' for Domain='%s'", hc.id(), domainName);
+               return hc.id();
+            }
+         }
       }
       return null;
    }
 
    public static void updateRoute53HealthCheckPath(String healthCheckId, String path) {
       try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
-            Route53Client route53 = Route53Client.builder().httpClient(httpClient).build()) {
+           Route53Client route53 = Route53Client.builder().httpClient(httpClient).build()) {
 
          LOG.infof("Updating Route53 HealthCheck '%s' to path='%s'", healthCheckId, path);
          route53.updateHealthCheck(
@@ -61,15 +103,15 @@ public class AWSClient {
    }
 
    public static String getRoute53HealthCheckPath(String healthCheckId) {
-        try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
-                Route53Client route53 = Route53Client.builder().httpClient(httpClient).build()) {
+      try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+           Route53Client route53 = Route53Client.builder().httpClient(httpClient).build()) {
 
-             return route53.getHealthCheck(
-                 GetHealthCheckRequest.builder()
-                         .healthCheckId(healthCheckId)
-                         .build()
-             ).healthCheck().healthCheckConfig().resourcePath();
-        }
+         return route53.getHealthCheck(
+               GetHealthCheckRequest.builder()
+                     .healthCheckId(healthCheckId)
+                     .build()
+         ).healthCheck().healthCheckConfig().resourcePath();
+      }
    }
 
    public static void waitForTheHealthCheckToBeInState(String healthCheckId, StateValue stateValue) {
@@ -89,16 +131,31 @@ public class AWSClient {
       }
    }
 
+   public static Accelerator getAccelerator(GlobalAcceleratorClient gaClient, String acceleratorDns) {
+      return gaClient.listAccelerators().accelerators()
+            .stream()
+            .filter(a -> acceleratorDns.contains(a.dnsName()))
+            .findFirst()
+            .orElseThrow();
+   }
+
+   public static AcceleratorMetadata getAcceleratorMeta(String acceleratorDns) {
+      return acceleratorClient((httpClient, gaClient) -> getAcceleratorMeta(gaClient, acceleratorDns));
+   }
+
+   public static AcceleratorMetadata getAcceleratorMeta(GlobalAcceleratorClient gaClient, String acceleratorDns) {
+      Accelerator accelerator = getAccelerator(gaClient, acceleratorDns);
+      return new AcceleratorMetadata(
+            accelerator.name(),
+            getEndpointGroup(gaClient, accelerator)
+      );
+   }
+
    public static void acceleratorFallback(String acceleratorDns) {
       acceleratorClient((httpClient, gaClient) -> {
          // Retrieve Accelerator instance based upon DNS
-         Accelerator accelerator = gaClient.listAccelerators().accelerators()
-               .stream()
-               .filter(a -> acceleratorDns.contains(a.dnsName()))
-               .findFirst()
-               .orElseThrow();
-
-         var endpointGroup = getEndpointGroup(gaClient, accelerator);
+         var acceleratorMeta = getAcceleratorMeta(gaClient, acceleratorDns);
+         var endpointGroup = acceleratorMeta.endpointGroup;
          var region = endpointGroup.endpointGroupRegion();
 
          List<String> endpoints;
@@ -123,7 +180,7 @@ public class AWSClient {
                         .contains(
                               Tag.builder()
                                     .key("accelerator")
-                                    .value(accelerator.name())
+                                    .value(acceleratorMeta.name())
                                     .build()
                         )
                   )
@@ -163,21 +220,12 @@ public class AWSClient {
    }
 
    public static List<String> getAcceleratorEndpoints(String acceleratorDns) {
-      return acceleratorClient((httpClient, gaClient) -> {
-               // Retrieve Accelerator instance based upon DNS
-               Accelerator accelerator = gaClient.listAccelerators().accelerators()
-                     .stream()
-                     .filter(a -> acceleratorDns.contains(a.dnsName()))
-                     .findFirst()
-                     .orElseThrow();
-
-               return getEndpointGroup(gaClient, accelerator)
-                     .endpointDescriptions()
-                     .stream()
-                     .map(EndpointDescription::endpointId)
-                     .toList();
-            }
-      );
+      return getAcceleratorMeta(acceleratorDns)
+            .endpointGroup
+            .endpointDescriptions()
+            .stream()
+            .map(EndpointDescription::endpointId)
+            .toList();
    }
 
    private static <T> T acceleratorClient(BiFunction<SdkHttpClient, GlobalAcceleratorClient, T> fn) {
@@ -191,4 +239,6 @@ public class AWSClient {
          return fn.apply(httpClient, gaClient);
       }
    }
+
+   public record AcceleratorMetadata(String name, EndpointGroup endpointGroup) {}
 }

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/DatacenterInfo.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/DatacenterInfo.java
@@ -22,6 +22,7 @@ public class DatacenterInfo implements AutoCloseable {
     private final KeycloakClient keycloak;
     private final ExternalInfinispanClient infinispan;
     private final OpenShiftClient oc;
+    private final PrometheusClient prometheus;
 
     public DatacenterInfo(HttpClient httpClient, int index, boolean activePassive) {
         oc = new KubernetesClientBuilder()
@@ -58,6 +59,7 @@ public class DatacenterInfo implements AutoCloseable {
 
         this.keycloak = new KeycloakClient(httpClient, keycloakServerURL, activePassive);
         this.infinispan = new ExternalInfinispanClient(infinispanServerURL, AbstractCrossDCTest.ISPN_USERNAME, AbstractCrossDCTest.MAIN_PASSWORD);
+        this.prometheus = new PrometheusClient(this);
     }
 
     private String getRouteHost(String app) {
@@ -105,5 +107,9 @@ public class DatacenterInfo implements AutoCloseable {
 
     public String namespace() {
         return namespace;
+    }
+
+    public PrometheusClient prometheus() {
+        return prometheus;
     }
 }

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/PrometheusClient.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/PrometheusClient.java
@@ -1,0 +1,53 @@
+package org.keycloak.benchmark.crossdc.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.keycloak.benchmark.crossdc.util.HttpClientUtils;
+
+import com.jayway.jsonpath.JsonPath;
+
+import net.minidev.json.JSONArray;
+
+public class PrometheusClient {
+
+   final String url;
+   final String token;
+
+   public PrometheusClient(DatacenterInfo dc) {
+      this.token = dc.oc().getConfiguration().getAutoOAuthToken();
+      this.url = String.format("https://%s/api/v1",
+            dc.oc().routes()
+                  .inNamespace("openshift-monitoring")
+                  .withName("thanos-querier")
+                  .get()
+                  .getSpec()
+                  .getHost()
+      );
+   }
+
+   public boolean isAlertFiring(String alertName) {
+      HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(url + "/alerts"))
+            .header("Authorization", "Bearer " + token)
+            .GET()
+            .build();
+
+      try {
+         var body = HttpClientUtils.newHttpClient()
+               .send(request, HttpResponse.BodyHandlers.ofString())
+               .body();
+
+         var jsonPath = String.format("$.data.alerts[?(@.labels.alertname == '%s' && @.state == 'firing')]", alertName);
+         JSONArray alerts = JsonPath.read(body, jsonPath);
+         return !alerts.isEmpty();
+      } catch (IOException e) {
+         throw new RuntimeException(e);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/util/K8sUtils.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/util/K8sUtils.java
@@ -1,0 +1,21 @@
+package org.keycloak.benchmark.crossdc.util;
+
+import java.util.concurrent.TimeUnit;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+public class K8sUtils {
+   public static void scaleDeployment(KubernetesClient k8s, String name, String namespace, int replicas) {
+      k8s.apps()
+            .deployments()
+            .inNamespace(namespace)
+            .withName(name)
+            .scale(replicas);
+
+      k8s.apps()
+            .deployments()
+            .inNamespace(namespace)
+            .withName(name)
+            .waitUntilReady(30, TimeUnit.SECONDS);
+   }
+}


### PR DESCRIPTION

Closes #854

The source of the original failures was fixed by https://github.com/keycloak/keycloak/pull/30841

However, when investigating the issue I realised that the testsuite was very flaky and failures often occurred when executing the `FailoverTest` in conjunction with the other tests. This PR reenables the active-active tests as well adding several fixes/improvements to the testsuite to reduce the chance of flaky failures.