### PR TITLE
Fix A/A deployment to not use caches

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -89,7 +89,7 @@ jobs:
     uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      externalInfinispanEnabled: true
+      skipEmbeddedCaches: true
     secrets: inherit
 
   run-scaling-benchmark-with-external-infinispan:
@@ -130,6 +130,8 @@ jobs:
     with:
       activeActive: true
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      skipEmbeddedCaches: true
+      skipRemoteCaches: true
     secrets: inherit
 
   run-scaling-benchmark-active-active:
@@ -171,7 +173,7 @@ jobs:
     with:
       activeActive: true
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      externalInfinispanEnabled: true
+      skipEmbeddedCaches: true
     secrets: inherit
 
   run-scaling-benchmark-active-active-with-external-infinispan:

--- a/.github/workflows/rosa-run-crossdc-func-tests.yml
+++ b/.github/workflows/rosa-run-crossdc-func-tests.yml
@@ -10,8 +10,12 @@ on:
         description: 'Must be true when testing against an Active/Active Keycloak deployment'
         type: boolean
         default: false
-      externalInfinispanEnabled:
-        description: 'True if the deployment uses the External Infinispan feature'
+      skipEmbeddedCaches:
+        description: 'True if the deployment does not use the Embedded Infinispan'
+        type: boolean
+        default: false
+      skipRemoteCaches:
+        description: 'True if the deployment does not use the External Infinispan'
         type: boolean
         default: false
 
@@ -24,8 +28,12 @@ on:
         description: 'Must be true when testing against an Active/Active Keycloak deployment'
         type: boolean
         default: false
-      externalInfinispanEnabled:
-        description: 'True if the deployment uses the External Infinispan feature'
+      skipEmbeddedCaches:
+        description: 'Skip assertions for embedded caches'
+        type: boolean
+        default: false
+      skipRemoteCaches:
+        description: 'Skip assertions for remote caches'
         type: boolean
         default: false
 
@@ -89,4 +97,5 @@ jobs:
         env:
           ACTIVE_ACTIVE: ${{ inputs.activeActive }}
           DEPLOYMENT_NAMESPACE: ${{ env.PROJECT }}
-          SKIP_EMBEDDED_CACHES: ${{ inputs.externalInfinispanEnabled }}
+          SKIP_EMBEDDED_CACHES: ${{ inputs.skipEmbeddedCaches }}
+          SKIP_REMOTE_CACHES: ${{ inputs.skipRemoteCaches }}

--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -78,6 +78,10 @@ spec:
   # tag::keycloak-ispn[]
   additionalOptions:
   # end::keycloak-ispn[]
+    {{- if .Values.persistentSessions }}
+    - name: spi-user-sessions-infinispan-use-caches
+      value: "false"
+    {{- end }}
     - name: http-metrics-histograms-enabled
       value: 'true'
     - name: http-metrics-slos

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/run-crossdc-tests.sh
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/run-crossdc-tests.sh
@@ -16,7 +16,8 @@ MVN_CMD="./mvnw -B -f provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/p
      -Dkubernetes.1.context=${KUBERNETES_1_CONTEXT} \
      -Dkubernetes.2.context=${KUBERNETES_2_CONTEXT} \
      -Dmain.password=${MAIN_PASSWORD} \
-     -DskipEmbeddedCaches=${SKIP_EMBEDDED_CACHES:-false}"
+     -DskipEmbeddedCaches=${SKIP_EMBEDDED_CACHES:-false} \
+     -DskipRemoteCaches=${SKIP_REMOTE_CACHES:-false}"
 
 if [ "${ACTIVE_ACTIVE}" == "true" ]; then
   MVN_CMD+=" -Pactive-active"

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/AbstractCrossDCTest.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/AbstractCrossDCTest.java
@@ -53,6 +53,7 @@ public abstract class AbstractCrossDCTest {
     public static final String USERNAME = "cross-dc-test-user";
     public static final String MAIN_PASSWORD = PropertyUtils.getRequired("main.password");
     public static final boolean SKIP_EMBEDDED_CACHES = Boolean.getBoolean("skipEmbeddedCaches");
+    public static final boolean SKIP_REMOTE_CACHES = Boolean.getBoolean("skipRemoteCaches");
 
     public AbstractCrossDCTest() {
         var httpClient = HttpClientUtils.newHttpClient();
@@ -239,6 +240,9 @@ public abstract class AbstractCrossDCTest {
     }
 
     protected static void assertExternalCacheSize(DatacenterInfo datacenterInfo, String cacheName, long expectedSize) {
+        if (SKIP_REMOTE_CACHES) {
+            return;
+        }
         assertCacheSize(datacenterInfo.ispn().cache(cacheName), expectedSize);
     }
 
@@ -266,10 +270,16 @@ public abstract class AbstractCrossDCTest {
     }
 
     protected static void assertExternalCacheContains(DatacenterInfo datacenterInfo, String cacheName, String expectedKey) throws URISyntaxException, IOException, InterruptedException {
+        if (SKIP_REMOTE_CACHES) {
+            return;
+        }
         assertContains(datacenterInfo.ispn().cache(cacheName), expectedKey, true);
     }
 
     protected static void assertExternalCacheNotContains(DatacenterInfo datacenterInfo, String cacheName, String expectedKey) throws URISyntaxException, IOException, InterruptedException {
+        if (SKIP_REMOTE_CACHES) {
+            return;
+        }
         assertContains(datacenterInfo.ispn().cache(cacheName), expectedKey, false);
     }
 


### PR DESCRIPTION
This addition changes current deployment to always disable caches when persistent sessions are used in multi site setup. 

Here is a test run: https://github.com/mhajas/keycloak-benchmark/actions/runs/10111381036/job/27963206863