### PR TITLE
optimize rosa scheduled workflow to run reduced combinations

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -36,7 +36,6 @@ jobs:
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here
       outputArchiveSuffix: 'active-active-external-infinispan'
-      skipCreateDataset: true
     secrets: inherit
 
   keycloak-undeploy-active-active-with-external-infinispan:

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -9,111 +9,49 @@ on:
 #   CLUSTER_PREFIX: gh-keycloak
 
 jobs:
-  cluster-create-keycloak-deploy:
-    name: ROSA Scheduled Create cluster A/P volatile sessions
+  keycloak-deploy-active-active-with-external-infinispan:
+    name: ROSA Scheduled Create Active/Active cluster with External Infinispan
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-    secrets: inherit
-
-  run-functional-tests:
-    needs: cluster-create-keycloak-deploy
-    uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-    secrets: inherit
-
-  run-scaling-benchmark:
-    needs: run-functional-tests
-    uses: ./.github/workflows/rosa-scaling-benchmark.yml
-    with:
-      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
-      outputArchiveSuffix: 'default'
-    secrets: inherit
-
-  keycloak-undeploy:
-    needs: run-scaling-benchmark
-    name: Undeploy Keycloak deployment on the multi-az cluster
-    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      skipAuroraDeletion: true
-    secrets: inherit
-
-  keycloak-deploy-with-persistent-sessions:
-    needs: keycloak-undeploy
-    name: ROSA Scheduled Create cluster with A/P Persistent Sessions
-    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      enablePersistentSessions: true
-      createCluster: false
-    secrets: inherit
-
-  run-scaling-benchmark-with-persistent-sessions:
-    needs: keycloak-deploy-with-persistent-sessions
-    uses: ./.github/workflows/rosa-scaling-benchmark.yml
-    with:
-      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
-      skipCreateDataset: true
-      outputArchiveSuffix: 'persistent-sessions'
-    secrets: inherit
-
-  keycloak-undeploy-with-persistent-sessions:
-    needs: run-scaling-benchmark-with-persistent-sessions
-    name: Undeploy Keycloak deployment on the multi-az cluster
-    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      skipAuroraDeletion: true
-    secrets: inherit
-
-  keycloak-deploy-with-external-infinispan:
-    needs: keycloak-undeploy-with-persistent-sessions
-    name: ROSA Scheduled Create cluster with A/P External Infinispan Feature
-    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      activeActive: true
       enableExternalInfinispanFeature: true
-      createCluster: false
     secrets: inherit
 
-  run-ap-functional-tests-with-external-infinispan:
-    needs: keycloak-deploy-with-external-infinispan
-    name: Runs the functional test suite in Active/Passive with the External Infinispan feature
+  run-functional-tests-active-active-with-external-infinispan:
+    needs: keycloak-deploy-active-active-with-external-infinispan
+    name: Runs the functional test suite in Active/Active with the External Infinispan feature
     uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
     with:
+      activeActive: true
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
       skipEmbeddedCaches: true
     secrets: inherit
 
-  run-scaling-benchmark-with-external-infinispan:
-    needs: run-ap-functional-tests-with-external-infinispan
-    name: Scaling Benchmark with Active/Passive External Infinispan Feature
+  run-scaling-benchmark-active-active-with-external-infinispan:
+    needs: run-functional-tests-active-active-with-external-infinispan
+    name: Scaling Benchmark with Active/Active External Infinispan Feature
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
-      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
+      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here
+      outputArchiveSuffix: 'active-active-external-infinispan'
       skipCreateDataset: true
-      outputArchiveSuffix: 'external-infinispan'
     secrets: inherit
 
-  keycloak-undeploy-with-external-infinispan:
-    needs: run-scaling-benchmark-with-external-infinispan
+  keycloak-undeploy-active-active-with-external-infinispan:
+    needs: run-scaling-benchmark-active-active-with-external-infinispan
     name: Undeploy Keycloak deployment on the multi-az cluster
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
       skipAuroraDeletion: true
+      activeActive: true
     secrets: inherit
 
   keycloak-deploy-active-active:
-    needs: keycloak-undeploy-with-external-infinispan
+    needs: keycloak-undeploy-active-active-with-external-infinispan
     name: ROSA Scheduled Create Active/Active cluster with Persistent Sessions
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
@@ -138,62 +76,18 @@ jobs:
     needs: run-functional-tests-active-active
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
-      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
+      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here
       outputArchiveSuffix: 'active-active'
       skipCreateDataset: true
     secrets: inherit
 
-  keycloak-undeploy-active-active:
-    needs: run-scaling-benchmark-active-active
-    name: Undeploy Keycloak deployment A/A
-    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      skipAuroraDeletion: true
-      activeActive: true
-    secrets: inherit
-
-  keycloak-deploy-active-active-with-external-infinispan:
-    needs: keycloak-undeploy-active-active
-    name: ROSA Scheduled Create Active/Active cluster with External Infinispan
-    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
-    with:
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      createCluster: false
-      activeActive: true
-      enableExternalInfinispanFeature: true
-    secrets: inherit
-
-  run-functional-tests-active-active-with-external-infinispan:
-    needs: keycloak-deploy-active-active-with-external-infinispan
-    name: Runs the functional test suite in Active/Active with the External Infinispan feature
-    uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
-    with:
-      activeActive: true
-      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      skipEmbeddedCaches: true
-    secrets: inherit
-
-  run-scaling-benchmark-active-active-with-external-infinispan:
-    needs: run-functional-tests-active-active-with-external-infinispan
-    name: Scaling Benchmark with Active/Active External Infinispan Feature
-    uses: ./.github/workflows/rosa-scaling-benchmark.yml
-    with:
-      clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here ${{ env.CLUSTER_PREFIX }}-a
-      outputArchiveSuffix: 'active-active-external-infinispan'
-      skipCreateDataset: true
-    secrets: inherit
-
-#  keycloak-undeploy-active-active-with-external-infinispan:
-#    needs: run-functional-tests-active-active-with-external-infinispan
-#    name: Undeploy Keycloak deployment on the multi-az cluster
+#  keycloak-undeploy-active-active:
+#    needs: run-scaling-benchmark-active-active
+#    name: Undeploy Keycloak deployment A/A
 #    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
 #    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
 #    with:
 #      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
 #      skipAuroraDeletion: true
-#      activeActive: true
+#     activeActive: true
 #    secrets: inherit
-

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -57,6 +57,7 @@ jobs:
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
       enablePersistentSessions: true
+      enableExternalInfinispanFeature: true
       createCluster: false
       activeActive: true
     secrets: inherit
@@ -79,14 +80,3 @@ jobs:
       outputArchiveSuffix: 'active-active'
       skipCreateDataset: true
     secrets: inherit
-
-#  keycloak-undeploy-active-active:
-#    needs: run-scaling-benchmark-active-active
-#    name: Undeploy Keycloak deployment A/A
-#    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-#    uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
-#    with:
-#      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-#      skipAuroraDeletion: true
-#     activeActive: true
-#    secrets: inherit


### PR DESCRIPTION
Fixes #900 

Trim the ROSA Scheduled workflow to only two combinations

- ROSA Scheduled Create Active/Active cluster with Volatile Sessions and External Infinispan
- ROSA Scheduled Create Active/Active cluster with Persistent Sessions and External Infinispan

Working run: https://github.com/kami619/keycloak-benchmark/actions/runs/10123478369