### PR TITLE
Support IPv6 for global accelerator

### DIFF
--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -203,9 +203,7 @@ jobs:
         if: ${{ inputs.activeActive }}
         working-directory: provision/rosa-cross-dc
         run: |
-          task global-accelerator-create 2>&1 | tee accelerator
-          echo "ACCELERATOR_DNS=$(grep -Po 'ACCELERATOR DNS: \K.*' accelerator | tail -1)" >> $GITHUB_ENV
-          echo "ACCELERATOR_WEBHOOK=$(grep -Po 'ACCELERATOR WEBHOOK: \K.*' accelerator | tail -1)" >> $GITHUB_ENV
+          task global-accelerator-create
         env:
           ACCELERATOR_NAME: ${{ env.CLUSTER_PREFIX }}
           ROSA_CLUSTER_NAME_1: ${{ env.CLUSTER_PREFIX }}-a

--- a/provision/aws/global-accelerator/accelerator_multi_az_create.sh
+++ b/provision/aws/global-accelerator/accelerator_multi_az_create.sh
@@ -84,5 +84,13 @@ TOFU_CMD="tofu apply -auto-approve \
 
 cd ${SCRIPT_DIR}/../../opentofu/modules/aws/accelerator
 source ${SCRIPT_DIR}/../../opentofu/create.sh ${ACCELERATOR_NAME} "${TOFU_CMD}"
-echo "ACCELERATOR DNS: $(tofu output -json | jq -r .dns_name.value)"
-echo "ACCELERATOR WEBHOOK: $(tofu output -json | jq -r .webhook_url.value)"
+
+ACCELERATOR_DNS=$(tofu output -json | jq -r .dns_name.value)
+ACCELERATOR_WEBHOOK=$(tofu output -json | jq -r .webhook_url.value)
+
+echo "ACCELERATOR DNS: ${ACCELERATOR_DNS}"
+echo "ACCELERATOR WEBHOOK: ${ACCELERATOR_WEBHOOK}"
+if [ "${GITHUB_ENV}" != "" ]; then
+  echo "ACCELERATOR_DNS=${ACCELERATOR_DNS}" >> ${GITHUB_ENV}
+  echo "ACCELERATOR_WEBHOOK=${ACCELERATOR_WEBHOOK}" >> ${GITHUB_ENV}
+fi

--- a/provision/opentofu/modules/aws/accelerator/.terraform.lock.hcl
+++ b/provision/opentofu/modules/aws/accelerator/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.48.0"
-  constraints = ">= 5.38.0"
+  constraints = ">= 4.61.0, >= 5.32.0, >= 5.38.0"
   hashes = [
     "h1:CzRLrszN3gtE7/fuxQcPzJM0MIzaE4pViSlOHk6QlkI=",
     "zh:212b33b4270a4f20025dec83b181b0e8044ef382491e0c89ad07c64d6dfacff0",

--- a/provision/opentofu/modules/aws/accelerator/main.tf
+++ b/provision/opentofu/modules/aws/accelerator/main.tf
@@ -19,6 +19,7 @@ module "global_accelerator" {
   source = "terraform-aws-modules/global-accelerator/aws"
 
   name = var.name
+  ip_address_type = "DUAL_STACK"
 
   listeners = {
     listener_1 = {

--- a/provision/opentofu/modules/aws/accelerator/output.tf
+++ b/provision/opentofu/modules/aws/accelerator/output.tf
@@ -1,5 +1,5 @@
 output "dns_name" {
-  value = module.global_accelerator.dns_name
+  value = module.global_accelerator.dual_stack_dns_name
 }
 
 output "webhook_url" {


### PR DESCRIPTION
Closes #911

Successful deployment: https://github.com/ahus1/keycloak-benchmark/actions/runs/10246749685/job/28344593381:

```
[global-accelerator-create] ACCELERATOR DNS: a16fa9b0d684c08cd.dualstack.awsglobalaccelerator.com
[global-accelerator-create] ACCELERATOR WEBHOOK: https://jy45j74qcvri4cgf3nbmcpel7u0fqcon.lambda-url.eu-west-1.on.aws/
```

