### PR TITLE
Use the same default value in helms chart and taskfile

### DIFF
--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -18,7 +18,7 @@ cacheDefaults:
   # NONE|NON_XA
   txMode: NON_XA
   # OPTIMISTIC|PESSIMISTIC
-  txLockMode: OPTIMISTIC
+  txLockMode: PESSIMISTIC
 caches:
   sessions:
     owners: 2


### PR DESCRIPTION
Use PESSIMISTIC transaction mode as default. It is faster for single key operations like put/remove/replace

I changed the default value in the task file [1] but forgot to update the helms chart. 

[1] https://github.com/keycloak/keycloak-benchmark/blob/main/provision/infinispan/Utils.yaml#L106