### PR TITLE
Testsuite fixes

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   keycloak-deploy-active-active-with-external-infinispan:
-    name: ROSA Scheduled Create Active/Active cluster with External Infinispan
+    name: ROSA Scheduled Create Active/Active cluster with External Infinispan and volatile sessions
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
     with:
@@ -52,14 +52,13 @@ jobs:
 
   keycloak-deploy-active-active:
     needs: keycloak-undeploy-active-active-with-external-infinispan
-    name: ROSA Scheduled Create Active/Active cluster with Persistent Sessions
+    name: ROSA Scheduled Create Active/Active cluster with External Infinispan and Persistent Sessions
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-create.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
-      enablePersistentSessionsFeature: true
-      enableExternalInfinispanFeature: true
       enableMultiSiteFeature: true
+      enableExternalInfinispanFeature: false
       createCluster: false
       activeActive: true
     secrets: inherit

--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -24,10 +24,6 @@ on:
         description: 'Set to true when version older than 26 is deployed'
         type: boolean
         default: false
-      enablePersistentSessionsFeature:
-        description: 'To enable Persistent user and client sessions to the DB'
-        type: boolean
-        default: false
       enableExternalInfinispanFeature:
         description: 'To enable the external Infinispan feature. It disables the embedded caches and only uses the remote caches.'
         type: boolean
@@ -60,10 +56,6 @@ on:
         default: false
       enableKc25Mode:
         description: 'Set to true when version older than 26 is deployed'
-        type: boolean
-        default: false
-      enablePersistentSessionsFeature:
-        description: 'To enable Persistent user and client sessions to the DB'
         type: boolean
         default: false
       enableExternalInfinispanFeature:

--- a/provision/aws/global-accelerator/accelerator_multi_az_delete.sh
+++ b/provision/aws/global-accelerator/accelerator_multi_az_delete.sh
@@ -23,7 +23,7 @@ if [ -z "${ACCELERATOR_NAME}" ]; then
     exit 1
   fi
   ACCELERATOR_NAME=$(aws globalaccelerator list-accelerators \
-    --query "Accelerators[?ends_with(DnsName, '${ACCELERATOR_DNS}')].Name" \
+    --query "Accelerators[?(ends_with(DnsName, '${ACCELERATOR_DNS}') || ends_with(DualStackDnsName, '${ACCELERATOR_DNS}'))].Name" \
     --output text
   )
   if [ -z "${ACCELERATOR_NAME}" ]; then

--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -101,8 +101,8 @@ tasks:
         --set hotrodPassword={{.CROSS_DC_HOT_ROD_PASSWORD}}
         --set cacheDefaults.crossSiteMode={{.CROSS_DC_MODE}}
         --set cacheDefaults.stateTransferMode={{.CROSS_DC_STATE_TRANSFER_MODE}}
-        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "FAIL" }}
-        --set cacheDefaults.txMode={{.CROSS_DC_TX_MODE | default "NON_XA" }}
+        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "WARN" }}
+        --set cacheDefaults.txMode={{.CROSS_DC_TX_MODE | default "NONE" }}
         --set cacheDefaults.txLockMode={{.CROSS_DC_TX_LOCK_MODE | default "PESSIMISTIC" }}
         --set image={{.CROSS_DC_IMAGE}}
         --set fd.interval={{.CROSS_DC_FD_INTERVAL}}

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -14,9 +14,9 @@ cacheDefaults:
   xsiteRemoteTimeout: 4500
   lockTimeout: 4000
   # WARN|FAIL|IGNORE. ASYNC only works with WARN|IGNORE
-  xsiteFailurePolicy: FAIL
+  xsiteFailurePolicy: WARN
   # NONE|NON_XA
-  txMode: NON_XA
+  txMode: NONE
   # OPTIMISTIC|PESSIMISTIC
   txLockMode: PESSIMISTIC
 caches:

--- a/provision/opentofu/modules/aws/accelerator/src/stonith_lambda.py
+++ b/provision/opentofu/modules/aws/accelerator/src/stonith_lambda.py
@@ -11,9 +11,7 @@ def handle_site_offline(labels):
     a_client = boto3.client('globalaccelerator', region_name='us-west-2')
 
     acceleratorDNS = labels['accelerator']
-    accelerator = jmespath.search(f"Accelerators[?DnsName=='{acceleratorDNS}']", a_client.list_accelerators())
-    if not accelerator:
-        accelerator = jmespath.search(f"Accelerators[?DualStackDnsName=='{acceleratorDNS}']", a_client.list_accelerators())
+    accelerator = jmespath.search(f"Accelerators[?(DnsName=='{acceleratorDNS}'|| DualStackDnsName=='{acceleratorDNS}')]", a_client.list_accelerators())
     if not accelerator:
         print(f"Ignoring SiteOffline alert as accelerator with DnsName '{acceleratorDNS}' not found")
         return


### PR DESCRIPTION
Reinstate WARN on backup failures until take-offline configuration in place, plus misc fixes to deployment scripts/actions.

This will fix the testsuite for deployments with persistent sessions, however a 401 is still thrown when testing with volatile sessions.