### PR TITLE
Take sites offline on split-brain

### DIFF
--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -140,6 +140,11 @@ jobs:
         with:
           tofu_wrapper: false
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12' # Must be the same as the python runtime specified in provision/opentofu/modules/aws/accelerator/main.tf
+
       - name: Setup ROSA CLI
         uses: ./.github/actions/rosa-cli-setup
         with:

--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -101,8 +101,8 @@ tasks:
         --set hotrodPassword={{.CROSS_DC_HOT_ROD_PASSWORD}}
         --set cacheDefaults.crossSiteMode={{.CROSS_DC_MODE}}
         --set cacheDefaults.stateTransferMode={{.CROSS_DC_STATE_TRANSFER_MODE}}
-        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "WARN" }}
-        --set cacheDefaults.txMode={{.CROSS_DC_TX_MODE | default "NONE" }}
+        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "FAIL" }}
+        --set cacheDefaults.txMode={{.CROSS_DC_TX_MODE | default "NON_XA" }}
         --set cacheDefaults.txLockMode={{.CROSS_DC_TX_LOCK_MODE | default "PESSIMISTIC" }}
         --set image={{.CROSS_DC_IMAGE}}
         --set fd.interval={{.CROSS_DC_FD_INTERVAL}}

--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -107,10 +107,6 @@ tasks:
         --set image={{.CROSS_DC_IMAGE}}
         --set fd.interval={{.CROSS_DC_FD_INTERVAL}}
         --set fd.timeout={{.CROSS_DC_FD_TIMEOUT}}
-        --set acceleratorDNS={{ .ACCELERATOR_DNS }}
-        --set alertmanager.webhook.url={{ .ACCELERATOR_WEBHOOK_URL }}
-        --set alertmanager.webhook.username={{ .ACCELERATOR_WEBHOOK_USERNAME }}
-        --set alertmanager.webhook.password={{ .ACCELERATOR_WEBHOOK_PASSWORD }}
         {{if eq .KC_KC25_MODE "true"}}--values ispn-helm/kc-25-caches.yaml{{end}}
         ./ispn-helm
     preconditions:
@@ -209,6 +205,30 @@ tasks:
       - .task/tokens/{{.TOKEN_FILE}}
     preconditions:
       - test -f ".task/kubecfg/{{.ROSA_CLUSTER_NAME}}"
+
+  deploy-xsite-infinispan-monitoring:
+    label: 'deploy-xsite-infinispan-monitoring-{{.ROSA_CLUSTER_NAME}}-{{.NAMESPACE}}'
+    internal: true
+    desc: "Deploy PrometheusRule and AlertManagerConfig for STONITH Lambda"
+    requires:
+      vars:
+        - NAMESPACE
+        - ROSA_CLUSTER_NAME
+    cmds:
+      - KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n {{.NAMESPACE}} wait --for=jsonpath="{.status.ingress[0].host}" route infinispan-external
+      - >
+        KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" helm upgrade --install infinispan-monitoring --namespace {{.NAMESPACE}}
+        --set acceleratorDNS={{ .ACCELERATOR_DNS }}
+        --set infinispanURL=$(KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n {{.NAMESPACE}} get route infinispan-external -o jsonpath='{.status.ingress[].host}')
+        --set alertmanager.webhook.url={{ .ACCELERATOR_WEBHOOK_URL }}
+        --set alertmanager.webhook.username={{ .ACCELERATOR_WEBHOOK_USERNAME }}
+        --set alertmanager.webhook.password={{ .ACCELERATOR_WEBHOOK_PASSWORD }}
+        --set crossdc.local.name={{.CROSS_DC_LOCAL_SITE}}
+        --set crossdc.remote.name={{.CROSS_DC_REMOTE_SITE}}
+        ./ispn-monitoring
+    sources:
+      - ispn-monitoring/**/*.*
+      - .task/subtask-{{.TASK}}.yaml
 
   wait-cluster:
     label: 'wait-cluster-{{.ROSA_CLUSTER_NAME}}-{{.NAMESPACE}}'
@@ -414,6 +434,18 @@ tasks:
         vars:
           ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_2}}"
           NAMESPACE: "{{.OC_NAMESPACE_2}}"
+      - task: deploy-xsite-infinispan-monitoring
+        vars:
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_1}}"
+          NAMESPACE: "{{.OC_NAMESPACE_1}}"
+          CROSS_DC_LOCAL_SITE: "{{.ROSA_CLUSTER_NAME_1}}"
+          CROSS_DC_REMOTE_SITE: "{{.ROSA_CLUSTER_NAME_2}}"
+      - task: deploy-xsite-infinispan-monitoring
+        vars:
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_2}}"
+          NAMESPACE: "{{.OC_NAMESPACE_2}}"
+          CROSS_DC_LOCAL_SITE: "{{.ROSA_CLUSTER_NAME_2}}"
+          CROSS_DC_REMOTE_SITE: "{{.ROSA_CLUSTER_NAME_1}}"
       - echo {{.TASK}} > ".task/kubecfg/ispn-{{.ROSA_CLUSTER_NAME_1}}"
       - echo {{.TASK}} > ".task/kubecfg/ispn-{{.ROSA_CLUSTER_NAME_2}}"
 

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -71,9 +71,3 @@ metrics:
 fd:
   interval: 2000
   timeout: 15000
-acceleratorDNS:
-alertmanager:
-  webhook:
-    url: ''
-    username: ''
-    password: ''

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -14,9 +14,9 @@ cacheDefaults:
   xsiteRemoteTimeout: 4500
   lockTimeout: 4000
   # WARN|FAIL|IGNORE. ASYNC only works with WARN|IGNORE
-  xsiteFailurePolicy: WARN
+  xsiteFailurePolicy: FAIL
   # NONE|NON_XA
-  txMode: NONE
+  txMode: NON_XA
   # OPTIMISTIC|PESSIMISTIC
   txLockMode: PESSIMISTIC
 caches:

--- a/provision/infinispan/ispn-monitoring/Chart.yaml
+++ b/provision/infinispan/ispn-monitoring/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ispn-monitoring
+description: Infinispan Monitoring Resources
+type: application
+version: 0.1.0
+appVersion: "15.0"

--- a/provision/infinispan/ispn-monitoring/templates/infinispan-alerts.yaml
+++ b/provision/infinispan/ispn-monitoring/templates/infinispan-alerts.yaml
@@ -57,5 +57,6 @@ spec:
             severity: critical
             reporter: {{ .Values.crossdc.local.name }} # <5>
             accelerator: {{ .Values.acceleratorDNS }} # <6>
+            infinispan: {{ .Values.infinispanURL }} # <7>
 # end::stonith-prometheus-rule[]
 {{ end }}

--- a/provision/infinispan/ispn-monitoring/values.yaml
+++ b/provision/infinispan/ispn-monitoring/values.yaml
@@ -1,0 +1,11 @@
+acceleratorDNS:
+alertmanager:
+  webhook:
+    url: ''
+    username: ''
+    password: ''
+crossdc:
+  local:
+    name:
+  remote:
+    name:

--- a/provision/opentofu/modules/aws/accelerator/main.tf
+++ b/provision/opentofu/modules/aws/accelerator/main.tf
@@ -65,7 +65,7 @@ module "lambda_function" {
   function_name              = var.name
   handler                    = "stonith_lambda.handler"
   runtime                    = "python3.12"
-  source_path                = "src/stonith_lambda.py"
+  source_path                = "src"
   create_lambda_function_url = true
   timeout                    = 15
 

--- a/provision/opentofu/modules/aws/accelerator/src/requirements.txt
+++ b/provision/opentofu/modules/aws/accelerator/src/requirements.txt
@@ -1,0 +1,11 @@
+boto3==1.34.116
+botocore==1.34.116
+certifi==2024.7.4
+charset-normalizer==3.3.2
+idna==3.7
+jmespath==1.0.1
+python-dateutil==2.9.0.post0
+requests==2.32.3
+s3transfer==0.10.1
+six==1.16.0
+urllib3==2.2.1

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/AbstractCrossDCTest.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/AbstractCrossDCTest.java
@@ -3,6 +3,7 @@ package org.keycloak.benchmark.crossdc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.keycloak.benchmark.crossdc.client.AWSClient.acceleratorClient;
 import static org.keycloak.benchmark.crossdc.util.HttpClientUtils.MOCK_COOKIE_MANAGER;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NAMES;
@@ -14,9 +15,12 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.AfterAll;
@@ -27,6 +31,7 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.benchmark.crossdc.client.AWSClient;
 import org.keycloak.benchmark.crossdc.client.DatacenterInfo;
+import org.keycloak.benchmark.crossdc.client.ExternalInfinispanClient;
 import org.keycloak.benchmark.crossdc.client.InfinispanClient;
 import org.keycloak.benchmark.crossdc.client.KeycloakClient;
 import org.keycloak.benchmark.crossdc.junit.tags.ActivePassive;
@@ -38,6 +43,10 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import jakarta.ws.rs.NotFoundException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.LoadBalancer;
+import software.amazon.awssdk.services.globalaccelerator.model.EndpointDescription;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractCrossDCTest {
@@ -194,6 +203,43 @@ public abstract class AbstractCrossDCTest {
               () -> AWSClient.getAcceleratorEndpoints(DC_1.getLoadbalancerURL()).size() == count,
               2, TimeUnit.MINUTES
         );
+    }
+
+    protected Set<String> getInfinispanSiteNamesInAccelerator() {
+        return acceleratorClient((httpClient, gaClient) -> {
+            var acceleratorMeta = AWSClient.getAcceleratorMeta(DC_1.getLoadbalancerURL());
+            var endpointGroup = acceleratorMeta.endpointGroup();
+            var region = endpointGroup.endpointGroupRegion();
+
+            try (ElasticLoadBalancingV2Client elbClient =
+                       ElasticLoadBalancingV2Client.builder()
+                             .region(Region.of(region))
+                             .httpClient(httpClient)
+                             .build()
+            ) {
+                var endpointIds = endpointGroup.endpointDescriptions()
+                      .stream()
+                      .map(EndpointDescription::endpointId)
+                      .collect(Collectors.toSet());
+
+                return elbClient.describeLoadBalancers().loadBalancers()
+                      .stream()
+                      .filter(lb -> endpointIds.contains(lb.loadBalancerArn()))
+                      .map(LoadBalancer::dnsName)
+                      .map(this::datacenterFromEndpointDNS)
+                      .map(DatacenterInfo::ispn)
+                      .map(ExternalInfinispanClient::siteName)
+                      .collect(Collectors.toSet());
+            }
+        });
+    }
+
+    private DatacenterInfo datacenterFromEndpointDNS(String dns) {
+        if (DC_1.getKeycloakServerURL().contains(dns))
+            return DC_1;
+        if (DC_2.getKeycloakServerURL().contains(dns))
+            return DC_2;
+        throw new IllegalStateException(String.format("Unknown Keycloak URL '%s'", dns));
     }
 
     protected void eventually(Supplier<String> messageSupplier, Supplier<Boolean> condition) {

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
@@ -243,7 +243,7 @@ public class AWSClient {
             .toList();
    }
 
-   private static <T> T acceleratorClient(BiFunction<SdkHttpClient, GlobalAcceleratorClient, T> fn) {
+   public static <T> T acceleratorClient(BiFunction<SdkHttpClient, GlobalAcceleratorClient, T> fn) {
       try (
             SdkHttpClient httpClient = ApacheHttpClient.builder().build();
             GlobalAcceleratorClient gaClient = GlobalAcceleratorClient.builder()


### PR DESCRIPTION
STONITH Lambda updated so the backup site of the "winning" AZ is explicitly taken offline. This is necessary in order for us to utilise a FAIL xsite strategy, as without it, the winning AZ would not be able to continue to serve user requests.

This approach requires the user to perform additional configuration steps:

1. A "infinispan" label must be added to the `PrometheusAlert` definition in each site. This label contains the exposed URL of the Infinispan cluster in that site.
2. An Infinispan username and password must be configured in the Lambda. The password should be retrieved via the AWS SecretsManager the same as the Keycloak password.

In order to allow 1. in our scripts, I have created an additional task "deploy-xsite-infinispan-monitoring".