### PR TITLE
Take sites offline on split-brain

### DIFF
--- a/.github/workflows/rosa-multi-az-cluster-create.yml
+++ b/.github/workflows/rosa-multi-az-cluster-create.yml
@@ -224,6 +224,7 @@ jobs:
         run: task active-active
         env:
           ACCELERATOR_DNS: ${{ env.ACCELERATOR_DNS }}
+          ACCELERATOR_NAME: ${{ env.CLUSTER_PREFIX }}
           ACCELERATOR_WEBHOOK_URL: ${{ env.ACCELERATOR_WEBHOOK }}
           ACCELERATOR_WEBHOOK_USERNAME: "keycloak"
           ACCELERATOR_WEBHOOK_PASSWORD: ${{ env.KEYCLOAK_ADMIN_PASSWORD }}

--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -576,3 +576,17 @@ tasks:
           KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n openshift-operators scale --replicas=1 deployment/infinispan-operator-controller-manager
           KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n openshift-operators rollout status -w deployment/infinispan-operator-controller-manager
           KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n ${NAMESPACE} rollout status -w deployment/infinispan-router
+
+  fetch-endpoint:
+    internal: true
+    requires:
+      vars:
+        - NAMESPACE
+        - ROSA_CLUSTER_NAME
+    cmds:
+      - task: rosa-oc-login
+        vars:
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME}}"
+      - KUBECONFIG=".task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n {{.NAMESPACE}} get route infinispan-external -o jsonpath='{.status.ingress[].host}' > .task/ispn-endpoint-{{.ROSA_CLUSTER_NAME}}
+    generates:
+      - .task/ispn-endpoint-{{.ROSA_CLUSTER_NAME}}

--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -101,8 +101,8 @@ tasks:
         --set hotrodPassword={{.CROSS_DC_HOT_ROD_PASSWORD}}
         --set cacheDefaults.crossSiteMode={{.CROSS_DC_MODE}}
         --set cacheDefaults.stateTransferMode={{.CROSS_DC_STATE_TRANSFER_MODE}}
-        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "WARN" }}
-        --set cacheDefaults.txMode={{.CROSS_DC_TX_MODE | default "NONE" }}
+        --set cacheDefaults.xsiteFailurePolicy={{.CROSS_DC_XSITE_FAIL_POLICY | default "FAIL" }}
+        --set cacheDefaults.txMode={{.CROSS_DC_TX_MODE | default "NON_XA" }}
         --set cacheDefaults.txLockMode={{.CROSS_DC_TX_LOCK_MODE | default "PESSIMISTIC" }}
         --set image={{.CROSS_DC_IMAGE}}
         --set fd.interval={{.CROSS_DC_FD_INTERVAL}}

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -14,9 +14,9 @@ cacheDefaults:
   xsiteRemoteTimeout: 4500
   lockTimeout: 4000
   # WARN|FAIL|IGNORE. ASYNC only works with WARN|IGNORE
-  xsiteFailurePolicy: WARN
+  xsiteFailurePolicy: FAIL
   # NONE|NON_XA
-  txMode: NONE
+  txMode: NON_XA
   # OPTIMISTIC|PESSIMISTIC
   txLockMode: PESSIMISTIC
 caches:

--- a/provision/opentofu/modules/aws/accelerator/src/stonith_lambda.py
+++ b/provision/opentofu/modules/aws/accelerator/src/stonith_lambda.py
@@ -1,10 +1,31 @@
-# tag::stonith-start[]
+# tag::fencing[]
+from urllib.error import HTTPError
+
 import boto3
 import jmespath
 import json
+import os
+import urllib3
 
 from base64 import b64decode
 from urllib.parse import unquote
+
+# Prevent unverified HTTPS connection warning
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class MissingEnvironmentVariable(Exception):
+    pass
+
+
+class MissingSiteUrl(Exception):
+    pass
+
+
+def env(name):
+    if name in os.environ:
+        return os.environ[name]
+    raise MissingEnvironmentVariable(f"Environment Variable '{name}' must be set")
 
 
 def handle_site_offline(labels):
@@ -40,6 +61,9 @@ def handle_site_offline(labels):
             EndpointConfigurations=endpoints
         )
         print(f"Removed site={offline_site} from Accelerator EndpointGroup")
+
+        take_infinispan_site_offline(reporter, offline_site)
+        print(f"Backup site={offline_site} caches taken offline")
     else:
         print("Ignoring SiteOffline alert only one Endpoint defined in the EndpointGroup")
 
@@ -55,11 +79,30 @@ def endpoint_belongs_to_site(endpoint, site):
     return false
 
 
-def get_secret(secret_name, region_name):
+def take_infinispan_site_offline(reporter, offlinesite):
+    endpoints = json.loads(INFINISPAN_SITE_ENDPOINTS)
+    if reporter not in endpoints:
+        raise MissingSiteUrl(f"Missing URL for site '{reporter}' in 'INFINISPAN_SITE_ENDPOINTS' json")
+
+    endpoint = endpoints[reporter]
+    password = get_secret(INFINISPAN_USER_SECRET)
+    url = f"https://{endpoint}/rest/v2/container/x-site/backups/{offlinesite}?action=take-offline"
+    http = urllib3.PoolManager(cert_reqs='CERT_NONE')
+    headers = urllib3.make_headers(basic_auth=f"{INFINISPAN_USER}:{password}")
+    try:
+        rsp = http.request("POST", url, headers=headers)
+        if rsp.status >= 400:
+            raise HTTPError(f"Unexpected response status '%d' when taking site offline", rsp.status)
+        rsp.release_conn()
+    except HTTPError as e:
+        print(f"HTTP error encountered: {e}")
+
+
+def get_secret(secret_name):
     session = boto3.session.Session()
     client = session.client(
         service_name='secretsmanager',
-        region_name=region_name
+        region_name=SECRETS_REGION
     )
     return client.get_secret_value(SecretId=secret_name)['SecretString']
 
@@ -90,14 +133,9 @@ def handler(event, context):
             "statusCode": 401
         }
 
-# end::stonith-start[]
-    expected_user = 'keycloak'
-    secret_name = 'keycloak-master-password'
-    secret_region = 'eu-central-1'
-# tag::stonith-end[]
-    expectedPass = get_secret(secret_name, secret_region)
+    expectedPass = get_secret(WEBHOOK_USER_SECRET)
     username, password = decode_basic_auth_header(authorization)
-    if username != expected_user and password != expectedPass:
+    if username != WEBHOOK_USER and password != expectedPass:
         print('Invalid username/password combination')
         return {
             "statusCode": 403
@@ -117,4 +155,12 @@ def handler(event, context):
     return {
         "statusCode": 204
     }
-# end::stonith-end[]
+
+
+INFINISPAN_USER = env('INFINISPAN_USER')
+INFINISPAN_USER_SECRET = env('INFINISPAN_USER_SECRET')
+INFINISPAN_SITE_ENDPOINTS = env('INFINISPAN_SITE_ENDPOINTS')
+SECRETS_REGION = env('SECRETS_REGION')
+WEBHOOK_USER = env('WEBHOOK_USER')
+WEBHOOK_USER_SECRET = env('WEBHOOK_USER_SECRET')
+# end::fencing[]

--- a/provision/rosa-cross-dc/Taskfile.yaml
+++ b/provision/rosa-cross-dc/Taskfile.yaml
@@ -333,6 +333,7 @@ tasks:
         - ROSA_CLUSTER_NAME_2
         - AURORA_CLUSTER
         - ACCELERATOR_DNS
+        - ACCELERATOR_NAME
         - ACCELERATOR_WEBHOOK_URL
         - ACCELERATOR_WEBHOOK_USERNAME
         - ACCELERATOR_WEBHOOK_PASSWORD
@@ -372,6 +373,7 @@ tasks:
       - task: create-env-configmap
         vars:
           ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_2}}"
+      - task: configure-lambda-env
 
   default:
     desc: "Deploys Infinispan, Aurora DB and Keycloak in a Active/Passive deployment using ROSA clusters"
@@ -994,3 +996,42 @@ tasks:
       - KUBECONFIG="{{.ISPN_DIR}}/.task/kubecfg/{{.ROSA_CLUSTER_NAME}}" kubectl -n {{.KC_NAMESPACE_PREFIX}}keycloak delete configmap env-config --ignore-not-found
     preconditions:
       - test -f "{{.ISPN_DIR}}/.task/kubecfg/{{.ROSA_CLUSTER_NAME}}"
+
+  configure-lambda-env:
+    internal: true
+    requires:
+      vars:
+        - ACCELERATOR_NAME
+        - ROSA_CLUSTER_NAME_1
+        - ROSA_CLUSTER_NAME_2
+    vars:
+      LAMBDA_REGION: "$(cat .task/rosa-region-{{.ROSA_CLUSTER_NAME_1}})"
+      ISPN_ENDPOINT_1: "$(cat {{.ISPN_DIR}}/.task/ispn-endpoint-{{.ROSA_CLUSTER_NAME_1}})"
+      ISPN_ENDPOINT_2: "$(cat {{.ISPN_DIR}}/.task/ispn-endpoint-{{.ROSA_CLUSTER_NAME_2}})"
+    cmds:
+      - task: fetch-rosa-region
+        vars:
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_1}}"
+      - task: ispn:fetch-endpoint
+        vars:
+          NAMESPACE: "{{.KC_ISPN_NAMESPACE}}"
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_1}}"
+      - task: ispn:fetch-endpoint
+        vars:
+          NAMESPACE: "{{.KC_ISPN_NAMESPACE}}"
+          ROSA_CLUSTER_NAME: "{{.ROSA_CLUSTER_NAME_2}}"
+      - |
+        export INFINISPAN_SITE_ENDPOINTS=$(echo "{\"{{.ROSA_CLUSTER_NAME_1}}\":\"{{.ISPN_ENDPOINT_1}}\",\"{{.ROSA_CLUSTER_NAME_2}}\":\"{{.ISPN_ENDPOINT_2}}\"}" | jq tostring)
+        aws lambda update-function-configuration \
+        --function-name {{.ACCELERATOR_NAME}} \
+        --region {{.LAMBDA_REGION}} \
+        --environment "{
+          \"Variables\": {
+            \"INFINISPAN_USER\" : \"developer\",
+            \"INFINISPAN_USER_SECRET\" : \"keycloak-master-password\",
+            \"INFINISPAN_SITE_ENDPOINTS\" : ${INFINISPAN_SITE_ENDPOINTS},
+            \"WEBHOOK_USER\" : \"keycloak\",
+            \"WEBHOOK_USER_SECRET\" : \"keycloak-master-password\",
+            \"SECRETS_REGION\" : \"eu-central-1\"
+          }
+        }"

--- a/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
+++ b/provision/rosa-cross-dc/keycloak-benchmark-crossdc-tests/src/test/java/org/keycloak/benchmark/crossdc/client/AWSClient.java
@@ -243,7 +243,7 @@ public class AWSClient {
             .toList();
    }
 
-   private static <T> T acceleratorClient(BiFunction<SdkHttpClient, GlobalAcceleratorClient, T> fn) {
+   public static <T> T acceleratorClient(BiFunction<SdkHttpClient, GlobalAcceleratorClient, T> fn) {
       try (
             SdkHttpClient httpClient = ApacheHttpClient.builder().build();
             GlobalAcceleratorClient gaClient = GlobalAcceleratorClient.builder()


### PR DESCRIPTION
STONITH Lambda updated so the backup site of the "winning" AZ is explicitly taken offline. This is necessary in order for us to utilise a FAIL xsite strategy, as without it, the winning AZ would not be able to continue to serve user requests.

This approach requires the user to perform additional configuration steps:

1. A "infinispan" label must be added to the `PrometheusAlert` definition in each site. This label contains the exposed URL of the Infinispan cluster in that site.
2. An Infinispan username and password must be configured in the Lambda. The password should be retrieved via the AWS SecretsManager the same as the Keycloak password.

In order to allow 1. in our scripts, I have created an additional task "deploy-xsite-infinispan-monitoring".

Closes #930