### PR TITLE
kc-rolling-restart.sh is enhanced to do a rolling restart on Infinispan pods

### DIFF
--- a/benchmark/src/main/content/bin/kc-rolling-restart.sh
+++ b/benchmark/src/main/content/bin/kc-rolling-restart.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Use this for deleting all Keycloak pods in sequence.
+# Use this for deleting all Keycloak or Infinispan pods in sequence.
 set -e
 
 if [[ "$RUNNER_DEBUG" == "1" ]]; then
@@ -8,27 +8,37 @@ fi
 
 : ${PROJECT:="runner-keycloak"}
 
-echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') Deleting all Keycloak pods in sequence\033[0m"
+# Ensure POD_LABEL is set
+if [[ -z "${POD_LABEL}" ]]; then
+  echo "POD_LABEL is not set. Please export POD_LABEL before running the script."
+  exit 1
+fi
 
-ALL_KC_PODS=$(kubectl -n "${PROJECT}" -o 'jsonpath={.items[*].metadata.name}' get pods -l app=keycloak | tr " " "\n")
+echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') Deleting all pods with label '${POD_LABEL}' in sequence\033[0m"
+
+ALL_PODS=$(kubectl -n "${PROJECT}" -o 'jsonpath={.items[*].metadata.name}' get pods -l app="${POD_LABEL}" | tr " " "\n")
 
 ATTEMPT=0
-for KC_POD in $ALL_KC_PODS; do
+for POD in $ALL_PODS; do
   ATTEMPT=$((ATTEMPT + 1))
-  kubectl get pods -n "${PROJECT}" -l app=keycloak
-  echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') Killing Pod '${KC_POD}'\033[0m"
-  kubectl delete pod -n "${PROJECT}" "${KC_POD}" --grace-period=1
+  kubectl get pods -n "${PROJECT}" -l app="${POD_LABEL}"
+  echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') Killing Pod '${POD}'\033[0m"
+  kubectl delete pod -n "${PROJECT}" "${POD}"
 
   START=$(date +%s)
 
-  kubectl wait --for=condition=Available --timeout=120s deployments.apps/keycloak-operator -n "${PROJECT}" || true
-  kubectl wait --for=condition=Ready --timeout=120s keycloaks.k8s.keycloak.org/keycloak -n "${PROJECT}" || true
+  if [[ "$POD_LABEL" == "keycloak" ]]; then
+    kubectl wait --for=condition=Available --timeout=120s deployments.apps/keycloak-operator -n "${PROJECT}" || true
+    kubectl wait --for=condition=Ready --timeout=120s keycloaks.k8s.keycloak.org/keycloak -n "${PROJECT}" || true
+  elif [[ "$POD_LABEL" == "infinispan-pod" ]]; then
+    kubectl wait --for condition=WellFormed --timeout=120s infinispans.infinispan.org -n "${PROJECT}" infinispan || true
+  fi
 
   END=$(date +%s)
   DIFF=$(( END - START ))
 
-  echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') Keycloak pod ${KC_POD} took ${DIFF} seconds to recover\033[0m"
+  echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') ${POD} pod took ${DIFF} seconds to recover\033[0m"
 done
 
-kubectl get pods -n "${PROJECT}" -l app=keycloak
-echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') All Keycloak pods have been processed.\033[0m"
+kubectl get pods -n "${PROJECT}" -l app="${POD_LABEL}"
+echo -e "\033[0;31mINFO:$(date '+%F-%T-%Z') All ${POD_LABEL} pods have been restarted.\033[0m"


### PR DESCRIPTION
Example usage:

```
> export PROJECT=kamesh-keycloak
> export POD_LABEL="infinispan-pod"
> ./kc-rolling-restart.sh
INFO:2024-09-05-09:52:42-EDT Deleting all infinispan-pod pods in sequence
NAME           READY   STATUS    RESTARTS   AGE
infinispan-0   1/1     Running   0          2m27s
infinispan-1   1/1     Running   0          22h
infinispan-2   1/1     Running   0          22h
INFO:2024-09-05-09:52:42-EDT Killing Pod 'infinispan-0'
pod "infinispan-0" deleted
infinispan.infinispan.org/infinispan condition met
INFO:2024-09-05-09:53:01-EDT infinispan-pod pod infinispan-0 took 16 seconds to recover
NAME           READY   STATUS    RESTARTS   AGE
infinispan-0   1/1     Running   0          16s
infinispan-1   1/1     Running   0          22h
infinispan-2   1/1     Running   0          22h
INFO:2024-09-05-09:53:01-EDT Killing Pod 'infinispan-1'
pod "infinispan-1" deleted
infinispan.infinispan.org/infinispan condition met
INFO:2024-09-05-09:53:20-EDT infinispan-pod pod infinispan-1 took 16 seconds to recover
NAME           READY   STATUS    RESTARTS   AGE
infinispan-0   1/1     Running   0          36s
infinispan-1   1/1     Running   0          17s
infinispan-2   1/1     Running   0          22h
INFO:2024-09-05-09:53:21-EDT Killing Pod 'infinispan-2'
pod "infinispan-2" deleted
infinispan.infinispan.org/infinispan condition met
INFO:2024-09-05-09:53:31-EDT infinispan-pod pod infinispan-2 took 9 seconds to recover
NAME           READY   STATUS    RESTARTS   AGE
infinispan-0   1/1     Running   0          46s
infinispan-1   1/1     Running   0          27s
infinispan-2   1/1     Running   0          9s
INFO:2024-09-05-09:53:31-EDT All infinispan-pod pods have been processed.


> export POD_LABEL="keycloak"
> ./kc-rolling-restart.sh
INFO:2024-09-05-09:55:01-EDT Deleting all keycloak pods in sequence
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          4m5s
keycloak-1   1/1     Running   0          22h
keycloak-2   1/1     Running   0          22h
INFO:2024-09-05-09:55:02-EDT Killing Pod 'keycloak-0'
pod "keycloak-0" deleted
deployment.apps/keycloak-operator condition met
keycloak.k8s.keycloak.org/keycloak condition met
INFO:2024-09-05-09:55:20-EDT keycloak pod keycloak-0 took 17 seconds to recover
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          17s
keycloak-1   1/1     Running   0          22h
keycloak-2   1/1     Running   0          22h
INFO:2024-09-05-09:55:20-EDT Killing Pod 'keycloak-1'
pod "keycloak-1" deleted
deployment.apps/keycloak-operator condition met
keycloak.k8s.keycloak.org/keycloak condition met
INFO:2024-09-05-09:55:39-EDT keycloak pod keycloak-1 took 17 seconds to recover
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          36s
keycloak-1   1/1     Running   0          17s
keycloak-2   1/1     Running   0          22h
INFO:2024-09-05-09:55:39-EDT Killing Pod 'keycloak-2'
pod "keycloak-2" deleted
deployment.apps/keycloak-operator condition met
keycloak.k8s.keycloak.org/keycloak condition met
INFO:2024-09-05-09:55:57-EDT keycloak pod keycloak-2 took 16 seconds to recover
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          55s
keycloak-1   1/1     Running   0          36s
keycloak-2   1/1     Running   0          17s
INFO:2024-09-05-09:55:58-EDT All keycloak pods have been processed.
```