### PR TITLE
Set missing POD_LABEL environment variable in GHA

### DIFF
--- a/.github/actions/keycloak-restart-pods/action.yml
+++ b/.github/actions/keycloak-restart-pods/action.yml
@@ -13,3 +13,5 @@ runs:
       shell: bash
       working-directory: benchmark/src/main/content/bin
       run: ./kc-rolling-restart.sh
+      env:
+        POD_LABEL: "keycloak"


### PR DESCRIPTION
Attempt to fix the nighty build: https://github.com/keycloak/keycloak-benchmark/actions/runs/10732714803/job/29766161807