### PR TITLE
Infinispan indexing switch

### DIFF
--- a/provision/infinispan/Utils.yaml
+++ b/provision/infinispan/Utils.yaml
@@ -109,6 +109,7 @@ tasks:
         --set fd.interval={{.CROSS_DC_FD_INTERVAL}}
         --set fd.timeout={{.CROSS_DC_FD_TIMEOUT}}
         --set createSessionsCaches={{.CROSS_DC_VOLATILE_SESSIONS}}
+        --set indexing={{.CROSS_DC_INDEXES | default "false"}}
         --set acceleratorDNS={{ .ACCELERATOR_DNS }}
         --set alertmanager.webhook.url={{ .ACCELERATOR_WEBHOOK_URL }}
         --set alertmanager.webhook.username={{ .ACCELERATOR_WEBHOOK_USERNAME }}

--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -157,6 +157,10 @@ spec:
       {{- end }}
       stateTransfer:
         chunkSize: "16"
+      {{- if and $.Values.indexing $config.indexing }}
+      indexing:
+        {{- toYaml $config.indexing | nindent 8}}
+      {{- end}}
       {{ if $.Values.crossdc.enabled }}
       {{- $_ := $.Values.crossdc.remote.name | required ".Values.crossdc.remote.name is required." -}}
       backups:

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -21,18 +21,38 @@ cacheDefaults:
   # OPTIMISTIC|PESSIMISTIC
   txLockMode: PESSIMISTIC
 caches:
-  sessions:
-    mergePolicy: ALWAYS_REMOVE
   actionTokens: {}
   authenticationSessions:
     mergePolicy: ALWAYS_REMOVE
+  sessions:
+    mergePolicy: ALWAYS_REMOVE
+    indexing:
+      enabled: true
+      indexed-entities:
+        - keycloak.RemoteUserSessionEntity
   offlineSessions:
     mergePolicy: ALWAYS_REMOVE
+    indexing:
+      enabled: true
+      indexed-entities:
+        - keycloak.RemoteUserSessionEntity
   clientSessions:
     mergePolicy: ALWAYS_REMOVE
+    indexing:
+      enabled: true
+      indexed-entities:
+        - keycloak.RemoteAuthenticatedClientSessionEntity
   offlineClientSessions:
     mergePolicy: ALWAYS_REMOVE
-  loginFailures: { }
+    indexing:
+      enabled: true
+      indexed-entities:
+        - keycloak.RemoteAuthenticatedClientSessionEntity
+  loginFailures:
+    indexing:
+      enabled: true
+      indexed-entities:
+        - keycloak.LoginFailureEntity
   work: { }
 crossdc:
   enabled: false
@@ -69,3 +89,4 @@ alertmanager:
 createSessionsCaches: 'false'
 cpu: '4:2'
 memory: '2Gi:1Gi'
+indexing: 'false'


### PR DESCRIPTION
Indexing is broken in Infinispan 15.0.8.Final. Use the following image if you want to try it

```
CROSS_DC_IMAGE=quay.io/pruivo/infinispan-server:15.0.9.Final-1
```

`CROSS_DC_INDEXES` taskfile variable enables it. 