### PR TITLE
Fix lambda removing site when site view was recovered

### DIFF
--- a/provision/opentofu/modules/aws/accelerator/src/stonith_lambda.py
+++ b/provision/opentofu/modules/aws/accelerator/src/stonith_lambda.py
@@ -147,6 +147,13 @@ def handler(event, context):
 
     body = json.loads(body)
     print(json.dumps(body))
+
+    if body['status'] != 'firing':
+        print("Ignoring alert as status is not 'firing', status was: '%s'" % body['status'])
+        return {
+            "statusCode": 204
+        }
+
     for alert in body['alerts']:
         labels = alert['labels']
         if labels['alertname'] == 'SiteOffline':


### PR DESCRIPTION
Closes #974

The current implementation is checking the status in the lambda, however, this could be theoretically improved to not call the lambda at all on the resolved event. However, I was not able to create a new [matcher](https://github.com/keycloak/keycloak-benchmark/blob/2cd91028bddfea8e05acabb2354894319d28503b/provision/infinispan/ispn-helm/templates/infinispan-alerts.yaml#L25) for the status as it seems the matcher works only on labels. 

I also tried to add a new alert label with the metric value, however, it reported 0 even for resolved alert :/. [Here](https://github.com/keycloak/keycloak-benchmark/blob/2cd91028bddfea8e05acabb2354894319d28503b/provision/infinispan/ispn-helm/templates/infinispan-alerts.yaml#L59) I did the following:
```
    - alert: SiteOffline
      expr: min by (namespace, site) (vendor_jgroups_site_view_status{namespace="runner-keycloak",site="gh-keycloak-a"})
        == 0
      labels:
        accelerator: aefa90b9a35667758.dualstack.awsglobalaccelerator.com
        reporter: gh-keycloak-b
        severity: critical
        status: '{{ $value }}' // this was added
```

Let me know if there is a way to not create an alert for resolved event as it would make a lot of sense to not call the lambda when not needed.