### PR TITLE
Changed the ispn cache name for which the metric should be retrieved.

### DIFF
--- a/.github/actions/prometheus-metrics-calc/action.yml
+++ b/.github/actions/prometheus-metrics-calc/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: 'A specific time period over which we want to calculate the required metrics.'
   ispnCacheName:
     description: 'ISPN cache name for which we need to calculate metrics.'
-    default: 'sessions'
+    default: 'authenticationSessions'
 
 runs:
   using: composite

--- a/.github/actions/prometheus-run-queries/action.yml
+++ b/.github/actions/prometheus-run-queries/action.yml
@@ -13,7 +13,7 @@ inputs:
     default: 'false'
   ispnCacheName:
     description: 'The name of the cache for which metrics should be retrieved.'
-    default: 'sessions'
+    default: 'authenticationSessions'
   output:
     description: 'The name of the output to store data in'
     default: 'out'


### PR DESCRIPTION
Updated the ISPN cache name as the sessions are stored in DB now. Chosen `authenticationSessions` cache, as it is used while login. After KC works mainly with DB.