### PR TITLE
update health checks to work for both A/A and A/P deployments

### DIFF
--- a/.github/workflows/keycloak-multi-site-health-check.yml
+++ b/.github/workflows/keycloak-multi-site-health-check.yml
@@ -74,6 +74,15 @@ jobs:
           KEYCLOAK_SITE_URL=https://$(kubectl -n "${{ inputs.project }}" get svc accelerator-loadbalancer --template="{{range .status.loadBalancer.ingress}}{{.hostname}}{{end}}")
           echo "KEYCLOAK_SITE_URL=$KEYCLOAK_SITE_URL" >> "$GITHUB_ENV"
 
+      - id: get-keycloak-site-a-url-from-r53
+        if: ${{ !inputs.activeActive }}
+        shell: bash
+        run: |
+          DOMAIN=$(./route53_fetch_domain.sh "keycloak-benchmark.com.")
+          KEYCLOAK_SITE_URL="https://primary.$DOMAIN"
+          echo "KEYCLOAK_SITE_URL=$KEYCLOAK_SITE_URL" >> "$GITHUB_ENV"
+        working-directory: provision/aws/route53
+
       - name: Perform Health checks on cluster A
         id: multi_site_health_check_a
         shell: bash
@@ -98,6 +107,15 @@ jobs:
         run: |
           KEYCLOAK_SITE_URL=https://$(kubectl -n "${{ inputs.project }}" get svc accelerator-loadbalancer --template="{{range .status.loadBalancer.ingress}}{{.hostname}}{{end}}")
           echo "KEYCLOAK_SITE_URL=$KEYCLOAK_SITE_URL" >> "$GITHUB_ENV"
+
+      - id: get-keycloak-site-b-url-from-r53
+        if: ${{ !inputs.activeActive }}
+        shell: bash
+        run: |
+          DOMAIN=$(./route53_fetch_domain.sh "keycloak-benchmark.com.")
+          KEYCLOAK_SITE_URL="https://backup.$DOMAIN"
+          echo "KEYCLOAK_SITE_URL=$KEYCLOAK_SITE_URL" >> "$GITHUB_ENV"
+        working-directory: provision/aws/route53
 
       - name: Perform Health checks on cluster B
         id: multi_site_health_check_b

--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -20,7 +20,7 @@ jobs:
       activeActive: true
     secrets: inherit
 
-  run-multi-site-health-checks-after-deploy:
+  run-active-active-health-checks-after-deploy:
     needs: keycloak-deploy-active-active
     name: Run multi-site health checks after deployment
     uses: ./.github/workflows/keycloak-multi-site-health-check.yml
@@ -33,7 +33,7 @@ jobs:
     secrets: inherit
 
   run-functional-tests-active-active:
-    needs: run-multi-site-health-checks-after-deploy
+    needs: run-active-active-health-checks-after-deploy
     uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
     with:
       activeActive: true
@@ -42,7 +42,7 @@ jobs:
       skipRemoteCaches: true
     secrets: inherit
 
-  run-multi-site-health-checks-after-functional-tests:
+  run-active-active-health-checks-after-functional-tests:
     needs: run-functional-tests-active-active
     name: Run multi-site health checks after functional tests
     uses: ./.github/workflows/keycloak-multi-site-health-check.yml
@@ -55,14 +55,14 @@ jobs:
     secrets: inherit
 
   run-scaling-benchmark-active-active:
-    needs: run-multi-site-health-checks-after-functional-tests
+    needs: run-active-active-health-checks-after-functional-tests
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here
       outputArchiveSuffix: 'active-active'
     secrets: inherit
 
-  run-multi-site-health-checks-after-benchmarks:
+  run-active-active-health-checks-after-benchmarks:
     needs: run-scaling-benchmark-active-active
     name: Run multi-site health checks after benchmarks
     uses: ./.github/workflows/keycloak-multi-site-health-check.yml
@@ -75,7 +75,7 @@ jobs:
     secrets: inherit
 
   keycloak-undeploy-active-active:
-    needs: run-multi-site-health-checks-after-benchmarks
+    needs: run-active-active-health-checks-after-benchmarks
     name: Undeploy Keycloak A/A deployment on the multi-az cluster
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-cluster-undeploy.yml
@@ -97,8 +97,20 @@ jobs:
       createCluster: false
     secrets: inherit
 
-  run-functional-tests-active-passive:
+  run-active-passive-health-checks-after-deploy:
     needs: keycloak-deploy-active-passive
+    name: Run multi-site health checks after benchmarks
+    uses: ./.github/workflows/keycloak-multi-site-health-check.yml
+    with:
+      activeActive: false
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      project: runner-keycloak
+      region: eu-west-1
+      expectedInfinispanNodeCount: '3'
+    secrets: inherit
+
+  run-functional-tests-active-passive:
+    needs: run-active-passive-health-checks-after-deploy
     uses: ./.github/workflows/rosa-run-crossdc-func-tests.yml
     with:
       clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
@@ -106,11 +118,35 @@ jobs:
       skipRemoteCaches: true
     secrets: inherit
 
-  run-scaling-benchmark-active-passive:
+  run-active-passive-health-checks-after-functional-tests:
     needs: run-functional-tests-active-passive
+    name: Run multi-site health checks after benchmarks
+    uses: ./.github/workflows/keycloak-multi-site-health-check.yml
+    with:
+      activeActive: false
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      project: runner-keycloak
+      region: eu-west-1
+      expectedInfinispanNodeCount: '3'
+    secrets: inherit
+
+  run-scaling-benchmark-active-passive:
+    needs: run-active-passive-health-checks-after-functional-tests
     uses: ./.github/workflows/rosa-scaling-benchmark.yml
     with:
       clusterName: gh-keycloak-a # ${{ env.CLUSTER_PREFIX }}-a -- unfortunately 'env.' doesn't work here
       skipCreateDataset: true
       outputArchiveSuffix: 'active-passive'
+    secrets: inherit
+
+  run-active-passive-health-checks-after-benchmarks:
+    needs: run-scaling-benchmark-active-passive
+    name: Run multi-site health checks after benchmarks
+    uses: ./.github/workflows/keycloak-multi-site-health-check.yml
+    with:
+      activeActive: false
+      clusterPrefix: gh-keycloak # ${{ env.CLUSTER_PREFIX }} -- unfortunately 'env.' doesn't work here
+      project: runner-keycloak
+      region: eu-west-1
+      expectedInfinispanNodeCount: '3'
     secrets: inherit

--- a/provision/aws/route53/route53_fetch_domain.sh
+++ b/provision/aws/route53/route53_fetch_domain.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Domain name (include trailing dot)
+DOMAIN=$1
+
+# Fetch Hosted Zone ID
+hosted_zone_id=$(aws route53 list-hosted-zones \
+    --query "HostedZones[?Name=='$DOMAIN'].Id" \
+    --output text)
+
+if [ -z "$hosted_zone_id" ]; then
+    echo "Hosted Zone ID for $DOMAIN not found."
+    exit 1
+fi
+
+# Remove '/hostedzone/' prefix from ID if present
+hosted_zone_id=${hosted_zone_id##*/}
+
+# List Resource Record Sets
+aws route53 list-resource-record-sets --hosted-zone-id "$hosted_zone_id" --query 'ResourceRecordSets[].Name' --output json | jq -r '.[]' | sed 's/\.$//' | sed 's/^[^.]*\.//' | grep -v '^keycloak-benchmark\.com$' | sort | uniq -c | sort -nr | head -1 | awk '{print $2}'
+


### PR DESCRIPTION
This PR addresses,
- Addition of script to fetch the Route53 domain dynamically and then construct the Keycloak Site Url.
- Add the health checks for Route 53 to the scheduled workflow.

Example Output of the script,

```
> DOMAIN=$(./route53_fetch_domain.sh "keycloak-benchmark.com.")
> echo $DOMAIN
gh-keycloak-a-gh-keycloak-b-mjqxmdyk.keycloak-benchmark.com
```