### PR TITLE
Reduce ClientSecrets scenario load

### DIFF
--- a/.github/workflows/rosa-scaling-benchmark.yml
+++ b/.github/workflows/rosa-scaling-benchmark.yml
@@ -30,7 +30,7 @@ on:
       numberOfClientsPerSecond:
         description: 'Client credential grants per second'
         type: number
-        default: 1000
+        default: 750
       measurement:
         description: 'Measurement period (seconds)'
         type: number
@@ -73,7 +73,7 @@ on:
       numberOfClientsPerSecond:
         description: 'Client credential grants per second'
         type: number
-        default: 1000
+        default: 750
       measurement:
         description: 'Measurement period (seconds)'
         type: number
@@ -93,7 +93,7 @@ env:
   PROJECT_PREFIX: runner- # same as default
   PROJECT: runner-keycloak
   ANSIBLE_CUSTOM_VARS_ARG: '-e @env_rosa_benchmark.yml'
-  CLIENTS_PER_REALM: 20000
+  CLIENTS_PER_REALM: 10000
 
 jobs:
   run:

--- a/provision/rosa-cross-dc/Taskfile.yaml
+++ b/provision/rosa-cross-dc/Taskfile.yaml
@@ -792,6 +792,7 @@ tasks:
     vars:
       SCENARIO: '{{.SCENARIO | default "keycloak.scenario.authentication.AuthorizationCode"}}'
       USERS: "{{.USERS | default 20000}}"
+      CLIENTS: "{{.CLIENTS | default 10000}}"
       USERS_PER_SEC: "{{.USERS_PER_SEC | default 150}}"
       DURATION: "{{.DURATION | default 600}}"
       REFRESH_TOKEN_COUNT: "{{.REFRESH_TOKEN_COUNT | default 0}}"
@@ -807,6 +808,7 @@ tasks:
         --realm-name=realm-0
         --logout-percentage={{.LOGOUT_PERCENTAGE}}
         --users-per-realm={{.USERS}}
+        --clients-per-realm={{.CLIENTS}}
         --ramp-up=20
         --log-http-on-failure
         --refresh-token-count={{.REFRESH_TOKEN_COUNT}}


### PR DESCRIPTION
* Current performance run is (over)loading the DB too much (98% CPU)
* Reduce the total number of clients to 10k (75% cache hit ratio)
* Reduce the requests per second to 750 (25% reduction)

Closes #1018