### PR TITLE
Fix jvm_gc_overhead metric name

### DIFF
--- a/doc/kubernetes/modules/ROOT/pages/running/metrics/jvm_metrics.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/running/metrics/jvm_metrics.adoc
@@ -43,7 +43,7 @@ m| jvm_gc_pause_seconds_sum
 m| jvm_gc_pause_seconds_count
 | Counts the total number of garbage collection pause events, helping to assess the frequency of GC pauses in the JVM.
 
-m| jvm_gc_overhead_percent
+m| jvm_gc_overhead
 | The percentage of CPU time spent on garbage collection, indicating the impact of GC on application performance in the JVM. It refers to the proportion of the total CPU processing time that is dedicated to executing garbage collection (GC) operations, as opposed to running application code or performing other tasks. This metric helps determine how much overhead GC introduces, affecting the overall performance of the {project_name}'s JVM.
 
 |===

--- a/provision/openshift/monitoring/dashboards/keycloak-perf-tests.json
+++ b/provision/openshift/monitoring/dashboards/keycloak-perf-tests.json
@@ -2085,7 +2085,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "max(jvm_gc_overhead_percent{namespace=\"$namespace\"}) by (pod)",
+          "expr": "max(jvm_gc_overhead{namespace=\"$namespace\"}) by (pod)",
           "format": "time_series",
           "instant": false,
           "legendFormat": "__auto",


### PR DESCRIPTION
It seems `jvm_gc_overhead_percent` was renamed to `jvm_gc_overhead`.