### PR TITLE
Update shade maven plugin add minimizeJar properties

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -122,6 +122,7 @@
                                     <exclude>org.scala-lang.modules:scala-java8-compat_2.13:*</exclude>
                                 </excludes>
                             </artifactSet>
+                            <minimizeJar>${minimize}</minimizeJar>
                         </configuration>
                     </execution>
                 </executions>
@@ -150,5 +151,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <minimize>false</minimize>
+            </properties>
+        </profile>
+        <profile>
+            <id>blazemeter</id>
+            <properties>
+                <minimize>true</minimize>
+            </properties>
+        </profile>
+    </profiles>
+
 
 </project>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -122,7 +122,7 @@
                                     <exclude>org.scala-lang.modules:scala-java8-compat_2.13:*</exclude>
                                 </excludes>
                             </artifactSet>
-                            <minimizeJar>${minimize}</minimizeJar>
+                            <minimizeJar>true</minimizeJar>
                         </configuration>
                     </execution>
                 </executions>
@@ -151,24 +151,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <minimize>false</minimize>
-            </properties>
-        </profile>
-        <profile>
-            <id>blazemeter</id>
-            <properties>
-                <minimize>true</minimize>
-            </properties>
-        </profile>
-    </profiles>
-
 
 </project>


### PR DESCRIPTION
Update shade maven plugin add minimizeJar properties to reduce the size of the generated jar
Add the minimizedJar because need to upload the jar into blazmeter but it's support upload with max size 50MB.