### PR TITLE
Enable rosa-cluster-auto-provision-on-schedule.yml after holidays

### DIFF
--- a/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
+++ b/.github/workflows/rosa-cluster-auto-provision-on-schedule.yml
@@ -1,8 +1,8 @@
 name: ROSA Daily Scheduled Run
 
 on:
-  #schedule:
-  #  - cron: '0 5 * * 1-5' # Runs At 05:00 UTC on every day-of-week from Monday through Friday.
+  schedule:
+    - cron: '0 5 * * 1-5' # Runs At 05:00 UTC on every day-of-week from Monday through Friday.
   workflow_dispatch:
 
 # env:


### PR DESCRIPTION
This reverts this PR: https://github.com/keycloak/keycloak-benchmark/pull/1081/files