### PR TITLE
monitoring upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ provision/environment_data.json
 **/*.terraform*
 !**/*.terraform.lock.hcl
 provision/opentofu/modules/aws/accelerator/builds/*
+
+# Grafana dashboard
+provision/minikube/monitoring/keycloak-grafana-dashboard

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -147,7 +147,7 @@ tasks:
     cmds:
       - helm repo add grafana https://grafana.github.io/helm-charts
       - helm repo update
-      - helm upgrade --install promtail grafana/promtail --version 6.3.0 -n monitoring -f promtail.yaml
+      - helm upgrade --install promtail grafana/promtail --version 6.16.6 -n monitoring -f promtail.yaml
     sources:
       - promtail.yaml
       - .task/subtask-{{.TASK}}.yaml

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -102,7 +102,7 @@ tasks:
       - helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
       - helm repo update
       - >
-        helm upgrade --install jaeger jaegertracing/jaeger --version 3.1.2 -n monitoring -f ../minikube/jaeger/values.yaml
+        helm upgrade --install jaeger jaegertracing/jaeger --version 3.4.0 -n monitoring -f ../minikube/jaeger/values.yaml
         --set allInOne.extraEnv[0].value={{.KB_RETENTION}}
     sources:
       - jaeger/**/*.*

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -72,7 +72,7 @@ tasks:
       - kubectl create namespace monitoring || true
       - helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
       - helm repo update
-      - helm upgrade --install prometheus prometheus-community/kube-prometheus-stack --version 67.9.0 -f monitoring.yaml --set grafana."grafana\.ini".server.root_url=https://grafana.{{.IP}}.nip.io --set prometheus.prometheusSpec.retention={{.KB_RETENTION}}
+      - helm upgrade --install prometheus prometheus-community/kube-prometheus-stack --version 69.7.3 -f monitoring.yaml --set grafana."grafana\.ini".server.root_url=https://grafana.{{.IP}}.nip.io --set prometheus.prometheusSpec.retention={{.KB_RETENTION}}
     sources:
       - monitoring.yaml
       - .task/subtask-{{.TASK}}.yaml

--- a/provision/minikube/Taskfile.yaml
+++ b/provision/minikube/Taskfile.yaml
@@ -133,8 +133,8 @@ tasks:
       - helm repo update
       # A loki update might fail as a stateful set can't be updated. If that fails, uninstall and re-install.
       - >
-        bash -c "helm upgrade --install loki grafana/loki --version 3.3.2 -n monitoring -f loki.yaml --set tableManager.retention_period={{.KB_RETENTION}}
-        || (helm delete loki -n monitoring && helm upgrade --install loki grafana/loki --version 3.3.2 -n monitoring -f loki.yaml --set tableManager.retention_period={{.KB_RETENTION}})"
+        bash -c "helm upgrade --install loki grafana/loki --version 6.27.0 -n monitoring -f loki.yaml --set tableManager.retention_period={{.KB_RETENTION}}
+        || (helm delete loki -n monitoring && helm upgrade --install loki grafana/loki --version 6.27.0 -n monitoring -f loki.yaml --set tableManager.retention_period={{.KB_RETENTION}})"
     sources:
       - loki.yaml
       - .task/subtask-{{.TASK}}.yaml

--- a/provision/minikube/isup.sh
+++ b/provision/minikube/isup.sh
@@ -25,6 +25,7 @@ declare -A SERVICES=( \
  ["jaeger.${HOST}"]="api/services" \
  ["kubebox.${HOST}"]="" \
  ["cryostat.${HOST}"]="" \
+ ["sqlpad.${HOST}"]="" \
  )
 
 for SERVICE in "${!SERVICES[@]}"; do

--- a/provision/minikube/keycloak/templates/keycloak-monitor.yaml
+++ b/provision/minikube/keycloak/templates/keycloak-monitor.yaml
@@ -11,6 +11,10 @@ spec:
   # Use pod target labels "as is" without any renaming
   # podTargetLabels:
   #   - app
+  # Since at least Keycloak 26.2 and the latest Quarkus 3.19 version, it requires "OpenMetricsText1.0.0" to retrieve exemplars,
+  # as at least some of the other protocols don't support exemplars.
+  scrapeProtocols:
+    - OpenMetricsText1.0.0
   podMetricsEndpoints:
     - port: management
       scheme: https

--- a/provision/minikube/keycloak/templates/sqlpad.yaml
+++ b/provision/minikube/keycloak/templates/sqlpad.yaml
@@ -46,7 +46,7 @@ spec:
             - name: SQLPAD_CONNECTIONS__pgdemo__username
               value: keycloak
             - name: SQLPAD_CONNECTIONS__pgdemo__password
-              value: pass
+              value: secret99
 {{ end }}
             - name: SQLPAD_CONNECTIONS__pgdemo__database
               value: keycloak

--- a/provision/minikube/loki.yaml
+++ b/provision/minikube/loki.yaml
@@ -4,9 +4,29 @@ loki:
     replication_factor: 1
   storage:
     type: 'filesystem'
+  schemaConfig:
+    configs:
+      - from: 2025-03-01
+        store: tsdb
+        index:
+          prefix: loki_index_
+          period: 24h
+        object_store: filesystem # we're storing on filesystem so there's no real persistence here.
+        schema: v13
   auth_enabled: false
   image:
     registry: mirror.gcr.io
+
+singleBinary:
+  replicas: 1
+read:
+  replicas: 0
+backend:
+  replicas: 0
+write:
+  persistence:
+    size: 1Gi
+  replicas: 0
 
 monitoring:
   rules:
@@ -22,10 +42,6 @@ monitoring:
 
 test:
   enabled: false
-
-write:
-  persistence:
-    size: 1Gi
 
 tableManager:
   retention_deletes_enabled: true

--- a/provision/minikube/loki.yaml
+++ b/provision/minikube/loki.yaml
@@ -16,16 +16,47 @@ loki:
   auth_enabled: false
   image:
     registry: mirror.gcr.io
+  pattern_ingester:
+    enabled: true
+  limits_config:
+    allow_structured_metadata: true
+    volume_enabled: true
+  ruler:
+    enable_api: true
+
+deploymentMode: SingleBinary
 
 singleBinary:
   replicas: 1
-read:
-  replicas: 0
+
+chunksCache:
+  enabled: false
+
+# Zero out replica counts of other deployment modes
 backend:
   replicas: 0
+read:
+  replicas: 0
 write:
-  persistence:
-    size: 1Gi
+  replicas: 0
+
+ingester:
+  replicas: 0
+querier:
+  replicas: 0
+queryFrontend:
+  replicas: 0
+queryScheduler:
+  replicas: 0
+distributor:
+  replicas: 0
+compactor:
+  replicas: 0
+indexGateway:
+  replicas: 0
+bloomCompactor:
+  replicas: 0
+bloomGateway:
   replicas: 0
 
 monitoring:

--- a/provision/minikube/monitoring.yaml
+++ b/provision/minikube/monitoring.yaml
@@ -60,7 +60,7 @@ grafana:
             filterByTraceID: true,
             mapTagNamesEnabled: true
             mappedTags:
-              - key: "hostname"
+              - key: "host.name"
                 value: "pod"
             spanStartTimeShift: "-1h"
             spanEndTimeShift: "1h"
@@ -75,7 +75,7 @@ grafana:
           maxLines: 1000
           derivedFields:
             - datasourceUid: PC9A941E8F2E49454
-              matcherRegex: '"trace_id":"(\w*)"'
+              matcherRegex: '"traceId":"(\w*)"'
               name: traceID
               # url will be interpreted as query for the datasource
               url: '$${__value.raw}'


### PR DESCRIPTION
- **Upgrade to kube-prometheus-stack 69.7.3**
- **Upgrade Jaeger to 3.4.0**
- **Upgrade Loki to 6.27.0**
- **Upgrade promtail to 6.16.6**
- **Don't track keycloak-grafana-dashboard**

All appears to be working as expected on my local `minikube` cluster. I wanted to utilise Jaeger v2, but it seems that's not currently possible with the helm chart https://github.com/jaegertracing/helm-charts/issues/610.
