### PR TITLE
Upgraded ROSA OCP to 4.17.20.

### DIFF
--- a/provision/opentofu/modules/rosa/hcp/variables.tf
+++ b/provision/opentofu/modules/rosa/hcp/variables.tf
@@ -55,7 +55,7 @@ variable "subnet_cidr_prefix" {
 
 variable "openshift_version" {
   type    = string
-  default = "4.17.10"
+  default = "4.17.20"
   nullable = false
 }
 


### PR DESCRIPTION
Upgrading OCP version to the latest 4.17 supported by ROSA.

List of currently supported versions: [4.18.5 4.18.4 4.18.3 4.18.2 4.18.1 4.17.20
│ 4.17.19 4.17.18 4.17.17 4.17.16 4.17.15 4.16.37 4.16.36 4.16.35 4.16.34
│ 4.15.47 4.15.46 4.15.45 4.14.48 4.14.46 4.14.45 4.14.44 4.14.43 4.14.42
│ 4.14.41 4.14.40 4.14.39 4.14.38 4.14.37 4.14.36 4.14.35 4.14.34 4.14.33
│ 4.14.32 4.14.31 4.14.30 4.14.29 4.14.28 4.13.55 4.13.54 4.13.53 4.13.52
│ 4.13.51 4.13.50 4.13.49 4.13.48 4.13.46 4.13.45 4.13.44 4.13.43 4.13.42
│ 4.13.41 4.13.40 4.13.39 4.13.38 4.13.37 4.13.36 4.13.35 4.13.34 4.13.33
│ 4.13.32 4.13.31 4.13.30 4.13.29 4.13.28 4.13.27 4.13.26 4.13.25 4.13.24
│ 4.13.23 4.13.22 4.13.21 4.13.19 4.13.18 4.13.17 4.13.15 4.13.14 4.13.13
│ 4.13.12 4.13.11 4.13.10]
