### PR TITLE
Set `keycloak.version` property in `0.14-release` branch to `26.0.4` for admin API compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <description>Keycloak Benchmark Parent</description>
 
   <properties>
-    <keycloak.version>999.0.0-SNAPSHOT</keycloak.version>
+    <keycloak.version>26.0.4</keycloak.version>
     <infinispan.version>15.0.8.Final</infinispan.version>
     <junit5.version>5.10.1</junit5.version>
     <httpclient.version>4.5.14</httpclient.version>


### PR DESCRIPTION
The version is set to `999.0.0-SNAPSHOT` which is not backward-compatible.