### PR TITLE
Increased `rosa_delete_cluster` timeout from 30m to 45m

### DIFF
--- a/provision/aws/rosa_delete_cluster.sh
+++ b/provision/aws/rosa_delete_cluster.sh
@@ -41,15 +41,16 @@ LOG_DIR="${SCRIPT_DIR}/logs/${CLUSTER_NAME}"
 mkdir -p ${LOG_DIR}
 cd ${LOG_DIR}
 echo "Starting to watch cluster uninstall logs."
-timeout -k 30m 30m bash -c "rosa logs uninstall -c ${CLUSTER_NAME} --watch --debug &> $(custom_date)_delete-cluster.log" &
+timeout -k 45m 45m bash -c "rosa logs uninstall -c ${CLUSTER_NAME} --watch --debug &> $(custom_date)_delete-cluster.log" &
 
 cd ${SCRIPT_DIR}/../opentofu/modules/rosa/hcp
 WORKSPACE=${CLUSTER_NAME}-${REGION}
-timeout -k 30m 30m bash -c "./../../../destroy.sh ${WORKSPACE}" &
+timeout -k 45m 45m bash -c "./../../../destroy.sh ${WORKSPACE}" &
 DESTROY_PROC_ID=$!
 
 if wait "${DESTROY_PROC_ID}"; then
     echo "Cluster uninstalled successfully."
 else
     echo "Timeout encountered deleting cluster"
+    exit 1
 fi


### PR DESCRIPTION
- Increased `rosa_delete_cluster` timeout from 30m to 45m.
- Added error exit code on timeout.

Recent cluster deletion took a bit over 30m, the workflow timed out but continued without failing:
```
...
rhcs_cluster_rosa_hcp.rosa_hcp_cluster: Still destroying... [id=2jslsmncdd8ot6pq6k9koc35veh7sii3, 29m0s elapsed]
rhcs_cluster_rosa_hcp.rosa_hcp_cluster: Still destroying... [id=2jslsmncdd8ot6pq6k9koc35veh7sii3, 29m10s elapsed]
rhcs_cluster_rosa_hcp.rosa_hcp_cluster: Still destroying... [id=2jslsmncdd8ot6pq6k9koc35veh7sii3, 29m20s elapsed]

Interrupt received.
Please wait for OpenTofu to exit or data loss may occur.
Gracefully shutting down...

Stopping operation...
Timeout encountered deleting cluster
```