### PR TITLE
Schedule stretched cluster run

### DIFF
--- a/.github/workflows/rosa-scheduled-run.yml
+++ b/.github/workflows/rosa-scheduled-run.yml
@@ -14,3 +14,20 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
     uses: ./.github/workflows/rosa-multi-az-clusters-run-tests.yml
     secrets: inherit
+
+  rosa-stretched-cluster:
+    name: Stretched Cluster - Create
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+    uses: ./.github/workflows/rosa-stretched-cluster.yml
+    secrets: inherit
+
+  rosa-stretched-cluster-benchmark:
+    name: Stretched Cluster - Benchmark
+    needs:
+      - rosa-stretched-cluster
+    if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
+    uses: ./.github/workflows/rosa-single-cluster-benchmark.yml
+    with:
+      clusterName: ${{ format('gh-{0}-az', github.repository_owner) }}
+      outputArchiveSuffix: "stretched-cluster"
+      clusterIdSuffix: "_sc"

--- a/.github/workflows/rosa-single-cluster-benchmark.yml
+++ b/.github/workflows/rosa-single-cluster-benchmark.yml
@@ -46,6 +46,9 @@ on:
         description: "Keycloak Operator deployment name"
         type: string
         default: keycloak-operator
+      clusterIdSuffix:
+        description: "Suffix to append to the AWS cluster where the benchmark will run."
+        type: string
 
   workflow_dispatch:
     inputs:
@@ -171,6 +174,7 @@ jobs:
         uses: ./.github/actions/ec2-create-instances
         with:
           region: ${{ inputs.region }}
+          clusterId: ${{ format('{0}{1}', github.run_id, inputs.clusterIdSuffix) }}
 
       - name: Prepare horreum report
         uses: ./.github/actions/prepare-horreum-report
@@ -203,7 +207,7 @@ jobs:
         continue-on-error: true
         working-directory: ansible
         env:
-          CLUSTER_ID: ${{ github.run_id }}
+          CLUSTER_ID: ${{ format('{0}{1}', github.run_id, inputs.clusterIdSuffix) }}
 
       - name: Run Memory Usage Total Query After Benchmark on Cluster 1
         uses: ./.github/actions/prometheus-run-queries
@@ -255,7 +259,7 @@ jobs:
         continue-on-error: true
         working-directory: ansible
         env:
-          CLUSTER_ID: ${{ github.run_id }}
+          CLUSTER_ID: ${{ format('{0}{1}', github.run_id, inputs.clusterIdSuffix) }}
 
       - name: Run CPU sec Util Query After Benchmark on Cluster 1
         uses: ./.github/actions/prometheus-run-queries
@@ -300,7 +304,7 @@ jobs:
         continue-on-error: true
         working-directory: ansible
         env:
-          CLUSTER_ID: ${{ github.run_id }}
+          CLUSTER_ID: ${{ format('{0}{1}', github.run_id, inputs.clusterIdSuffix) }}
 
       - name: Run CPU sec Util Query After Benchmark on Cluster 1
         uses: ./.github/actions/prometheus-run-queries
@@ -354,6 +358,7 @@ jobs:
         uses: ./.github/actions/ec2-delete-instances
         with:
           region: ${{ inputs.region }}
+          clusterId: ${{ format('{0}{1}', github.run_id, inputs.clusterIdSuffix) }}
 
   archive:
     name: Commit results to Git repository


### PR DESCRIPTION
I added a suffix to the benchmark AWS cluster as I'm concerned that they may interfere with each other due to the same `github.run_id`