### PR TITLE
Benchmark workflows failing due to multiple jars in benchmark distribution

### DIFF
--- a/benchmark/src/main/content/bin/kcb.sh
+++ b/benchmark/src/main/content/bin/kcb.sh
@@ -110,7 +110,7 @@ if [ "$DEBUG_MODE" = "true" ]; then
     fi
 fi
 
-CLASSPATH_OPTS="$DIRNAME/../lib/*"
+CLASSPATH_OPTS=$(find $DIRNAME/../lib -type f | paste -sd:)
 
 declare -A RESULT_CACHE
 


### PR DESCRIPTION
Closes #1197

Successful run of the benchmarks on my fork: https://github.com/ryanemerson/keycloak-benchmark/actions/runs/17409642029