### PR TITLE
Fix terraform AWS cross-region secret handling.

### DIFF
--- a/.github/workflows/rosa-cluster-create.yml
+++ b/.github/workflows/rosa-cluster-create.yml
@@ -86,6 +86,7 @@ jobs:
           AVAILABILITY_ZONES: ${{ inputs.availabilityZones }}
           CIDR: ${{ inputs.cidr }}
           CLUSTER_NAME: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
+          CLUSTER_ADMIN_PASSWORD: ${{ env.KEYCLOAK_ADMIN_PASSWORD }}
           COMPUTE_MACHINE_TYPE: ${{ inputs.computeMachineType }}
           REPLICAS: ${{ inputs.replicas }}
           TF_VAR_rhcs_token: ${{ secrets.ROSA_TOKEN }}

--- a/.github/workflows/rosa-cluster-delete.yml
+++ b/.github/workflows/rosa-cluster-delete.yml
@@ -62,6 +62,7 @@ jobs:
         working-directory: provision/aws
         env:
           CLUSTER_NAME: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
+          CLUSTER_ADMIN_PASSWORD: ${{ env.KEYCLOAK_ADMIN_PASSWORD }}
           TF_VAR_rhcs_token: ${{ secrets.ROSA_TOKEN }}
 
       - name: Delete all ROSA Clusters

--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -29,6 +29,7 @@ echo "Checking if cluster ${CLUSTER_NAME} already exists."
 if rosa describe cluster --cluster="${CLUSTER_NAME}"; then
   echo "Cluster ${CLUSTER_NAME} already exists."
 else
+  if [ -z "$CLUSTER_ADMIN_PASSWORD" ]; then echo "CLUSTER_ADMIN_PASSWORD needs to be set."; exit 1; fi
   echo "Verifying ROSA prerequisites."
   echo "Check if AWS CLI is installed."; aws --version
   echo "Check if ROSA CLI is installed."; rosa version
@@ -48,6 +49,7 @@ else
     -var vpc_cidr=${CIDR} \
     -var availability_zones=${AVAILABILITY_ZONES} \
     -var cluster_name=${CLUSTER_NAME} \
+    -var cluster_admin_password=${CLUSTER_ADMIN_PASSWORD} \
     -var region=${REGION}"
 
   if [ -n "${COMPUTE_MACHINE_TYPE}" ]; then

--- a/provision/opentofu/destroy.sh
+++ b/provision/opentofu/destroy.sh
@@ -13,7 +13,10 @@ if tofu workspace select ${WORKSPACE}; then
   OUTPUTS=$(tofu output)
   echo "${OUTPUTS}"
   INPUTS=$(echo "${OUTPUTS}" | sed -n 's/input_//p' | sed 's/ //g' | sed 's/^/-var /' | tr -d '"')
-  DESTROY_CMD="tofu destroy -auto-approve ${INPUTS} -lock-timeout=15m"
+  # CLUSTER_ADMIN_PASSWORD is not necessary for cluster deletion but is required by the 'tofu destroy' command anyway
+  # See: https://github.com/hashicorp/terraform/issues/18994
+  if [ -z "$CLUSTER_ADMIN_PASSWORD" ]; then echo "CLUSTER_ADMIN_PASSWORD needs to be set."; exit 1; fi
+  DESTROY_CMD="tofu destroy -auto-approve ${INPUTS} -var cluster_admin_password=\"$CLUSTER_ADMIN_PASSWORD\" -lock-timeout=15m"
   echo ${DESTROY_CMD}
   ${DESTROY_CMD}
   tofu state list

--- a/provision/opentofu/modules/rosa-hcp/main.tf
+++ b/provision/opentofu/modules/rosa-hcp/main.tf
@@ -1,15 +1,3 @@
-data "aws_caller_identity" "current" {
-}
-
-data "aws_secretsmanager_secret" "secrets" {
-  region = "eu-central-1"
-  name = "keycloak-master-password"
-}
-
-data "aws_secretsmanager_secret_version" "current" {
-  secret_id = data.aws_secretsmanager_secret.secrets.id
-}
-
 module "vpc" {
   source                = "terraform-redhat/rosa-hcp/rhcs//modules/vpc"
 
@@ -39,6 +27,6 @@ module "hcp" {
 
   // admin credentials
   admin_credentials_username = "cluster-admin"
-  admin_credentials_password = nonsensitive(data.aws_secretsmanager_secret_version.current.secret_string)
+  admin_credentials_password = var.cluster_admin_password
 }
 

--- a/provision/opentofu/modules/rosa-hcp/variables.tf
+++ b/provision/opentofu/modules/rosa-hcp/variables.tf
@@ -3,6 +3,11 @@ variable "rhcs_token" {
   sensitive = true
 }
 
+variable "cluster_admin_password" {
+  type      = string
+  sensitive = true
+}
+
 variable "region" {
   description = <<-EOT
     Region to create AWS infrastructure resources for a


### PR DESCRIPTION
After investigating a terraform-native solution (which involves importing the password resource across regions via additional aws provider using the secret's ARN as a input param), I ended up passing the password to tofu from the env variable.

Closes #1220