### PR TITLE
Fix tofu `destroy.sh` script.

### DIFF
--- a/.github/workflows/rosa-cluster-delete.yml
+++ b/.github/workflows/rosa-cluster-delete.yml
@@ -62,7 +62,6 @@ jobs:
         working-directory: provision/aws
         env:
           CLUSTER_NAME: ${{ inputs.clusterName || format('gh-{0}', github.repository_owner) }}
-          CLUSTER_ADMIN_PASSWORD: ${{ env.KEYCLOAK_ADMIN_PASSWORD }}
           TF_VAR_rhcs_token: ${{ secrets.ROSA_TOKEN }}
 
       - name: Delete all ROSA Clusters

--- a/provision/opentofu/destroy.sh
+++ b/provision/opentofu/destroy.sh
@@ -13,10 +13,7 @@ if tofu workspace select ${WORKSPACE}; then
   OUTPUTS=$(tofu output)
   echo "${OUTPUTS}"
   INPUTS=$(echo "${OUTPUTS}" | sed -n 's/input_//p' | sed 's/ //g' | sed 's/^/-var /' | tr -d '"')
-  # CLUSTER_ADMIN_PASSWORD is not necessary for cluster deletion but is required by the 'tofu destroy' command anyway
-  # See: https://github.com/hashicorp/terraform/issues/18994
-  if [ -z "$CLUSTER_ADMIN_PASSWORD" ]; then echo "CLUSTER_ADMIN_PASSWORD needs to be set."; exit 1; fi
-  DESTROY_CMD="tofu destroy -auto-approve ${INPUTS} -var cluster_admin_password=\"$CLUSTER_ADMIN_PASSWORD\" -lock-timeout=15m"
+  DESTROY_CMD="tofu destroy -auto-approve ${INPUTS} -lock-timeout=15m"
   echo ${DESTROY_CMD}
   ${DESTROY_CMD}
   tofu state list

--- a/provision/opentofu/modules/rosa-hcp/output.tf
+++ b/provision/opentofu/modules/rosa-hcp/output.tf
@@ -12,3 +12,8 @@ output "input_availability_zones" {
   value       = var.availability_zones
   description = "The Availability Zones AWS resources created in."
 }
+
+output "input_cluster_admin_password" {
+  value       = "DummyPasswordValue1!"
+  description = "Dummy value. Required as an input for destroy-plan, not for the actual destruction."
+}


### PR DESCRIPTION
- Remove rosa-specific `CLUSTER_ADMIN_PASSWORD` handling from the script, and dependent GHA workflow.
- Add a dummy password value to `rosa-hcp/output.tf`.