### PR TITLE
Enable rolling updates for patch releases and set update strategy to `Auto` by default

### DIFF
--- a/provision/minikube/keycloak/templates/keycloak.yaml
+++ b/provision/minikube/keycloak/templates/keycloak.yaml
@@ -67,8 +67,11 @@ spec:
   image: {{ .Values.keycloakImage }} # <3>
   startOptimized: {{ .Values.startOptimized }} # <3>
 {{ end }}
+  update:
+    strategy: Auto
   features:
     enabled:
+      - rolling-updates:v2
 {{- if .Values.multiSite }}
       - multi-site # <4>
 {{- end }}


### PR DESCRIPTION
```
apiVersion: k8s.keycloak.org/v2alpha1
kind: Keycloak
metadata:
  name: example-kc
spec:
  features:
    enabled:
      - rolling-updates:v2
  update:
    strategy: Auto
```
https://www.keycloak.org/operator/rolling-updates