### PR TITLE
Update Infinispan CRs in multi-cluster architecture to use InPlaceRolling upgrade strategy

### DIFF
--- a/provision/infinispan/ispn-helm/templates/infinispan.yaml
+++ b/provision/infinispan/ispn-helm/templates/infinispan.yaml
@@ -133,6 +133,8 @@ spec:
           {{ end }}
           {{- end }}
     {{- end }}
+  upgrades:
+    type: InPlaceRolling
     # end::infinispan-crossdc[]
 {{range $cache, $config := .Values.caches -}}
   {{- if and (not $.Values.createSessionsCaches) (eq $cache "sessions" "offlineSessions" "clientSessions" "offlineClientSessions") }}


### PR DESCRIPTION
Closes keycloak/keycloak#45424

Tested by deploying with an external Infinispan + volatile sessions. User logged in, Infinispan upgraded from 16.0.1 to 16.0.5 using an in place upgrade and the original session still existed.