### PR TITLE
Pass the `uniqueCredentials` input parameter to benchmark

### DIFF
--- a/.github/workflows/rosa-multi-cluster-benchmark.yml
+++ b/.github/workflows/rosa-multi-cluster-benchmark.yml
@@ -231,6 +231,7 @@ jobs:
           --logout-percentage=0
           --measurement=${{ inputs.measurement }}
           --users-per-realm=${{ inputs.usersPerRealm }}
+          --unique-credential-count=${{ inputs.uniqueCredentials }}
           --clients-per-realm=${{ env.CLIENTS_PER_REALM }}
           --log-http-on-failure
           --sla-error-percentage=0.001
@@ -316,6 +317,7 @@ jobs:
           --logout-percentage=100
           --measurement=${{ inputs.measurement }}
           --users-per-realm=${{ inputs.usersPerRealm }}
+          --unique-credential-count=${{ inputs.uniqueCredentials }}
           --clients-per-realm=${{ env.CLIENTS_PER_REALM }}
           --log-http-on-failure
           --sla-error-percentage=0.001
@@ -394,6 +396,7 @@ jobs:
           --ramp-up=20
           --measurement=${{ inputs.measurement }}
           --users-per-realm=${{ inputs.usersPerRealm }}
+          --unique-credential-count=${{ inputs.uniqueCredentials }}
           --clients-per-realm=${{ env.CLIENTS_PER_REALM }}
           --log-http-on-failure
           --sla-error-percentage=0.001

--- a/.github/workflows/rosa-single-cluster-benchmark.yml
+++ b/.github/workflows/rosa-single-cluster-benchmark.yml
@@ -209,6 +209,7 @@ jobs:
           --logout-percentage=0
           --measurement=${{ inputs.measurement }}
           --users-per-realm=${{ inputs.usersPerRealm }}
+          --unique-credential-count=${{ inputs.uniqueCredentials }}
           --clients-per-realm=${{ env.CLIENTS_PER_REALM }}
           --log-http-on-failure
           --sla-error-percentage=0.001
@@ -261,6 +262,7 @@ jobs:
           --logout-percentage=100
           --measurement=${{ inputs.measurement }}
           --users-per-realm=${{ inputs.usersPerRealm }}
+          --unique-credential-count=${{ inputs.uniqueCredentials }}
           --clients-per-realm=${{ env.CLIENTS_PER_REALM }}
           --log-http-on-failure
           --sla-error-percentage=0.001
@@ -306,6 +308,7 @@ jobs:
           --ramp-up=20
           --measurement=${{ inputs.measurement }}
           --users-per-realm=${{ inputs.usersPerRealm }}
+          --unique-credential-count=${{ inputs.uniqueCredentials }}
           --clients-per-realm=${{ env.CLIENTS_PER_REALM }}
           --log-http-on-failure
           --sla-error-percentage=0.001


### PR DESCRIPTION
Fixes inconsistent handling of passwords between dataset generator and benchmark.