### PR TITLE
Enable OpenShift user workload monitoring according to updated docs

### DIFF
--- a/provision/aws/rosa_create_cluster.sh
+++ b/provision/aws/rosa_create_cluster.sh
@@ -82,8 +82,10 @@ cd ${SCRIPT_DIR}
 
 ./rosa_install_tempo_operator.sh
 
-echo "Enabling user alert routing."
+echo "Enabling monitoring for user workloads"
 oc apply -f ${SCRIPT_DIR}/../openshift/cluster-monitoring-config.yaml
+echo "Enabling user alert routing"
+oc apply -f ${SCRIPT_DIR}/../openshift/user-workload-monitoring-config.yaml
 waitFor openshift-user-workload-monitoring statefulset alertmanager-user-workload
 oc -n openshift-user-workload-monitoring rollout status --watch --timeout=2m statefulset.apps/alertmanager-user-workload
 

--- a/provision/openshift/cluster-monitoring-config.yaml
+++ b/provision/openshift/cluster-monitoring-config.yaml
@@ -1,11 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: user-workload-monitoring-config
-  namespace: openshift-user-workload-monitoring
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
 data:
   config.yaml: |
-    alertmanager:
-      enabled: true
-      enableAlertmanagerConfig: true
-      logLevel: debug
+    enableUserWorkload: true

--- a/provision/openshift/user-workload-monitoring-config.yaml
+++ b/provision/openshift/user-workload-monitoring-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    alertmanager:
+      enabled: true
+      enableAlertmanagerConfig: true
+      logLevel: debug


### PR DESCRIPTION
Enable OpenShift user workload monitoring [according to updated docs](https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.18/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm#enabling-monitoring-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm
).

Fixes an issue with an ROSA install script which is indefinitely waiting for Alertmanager stateful set.