### PR TITLE
Ensure that node ports for the nginx ingress are available when cilium is enabled

### DIFF
--- a/.github/workflows/provision-minikube.yml
+++ b/.github/workflows/provision-minikube.yml
@@ -26,7 +26,7 @@ jobs:
   build:
 
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak-benchmark'
-    
+
     runs-on: ubuntu-latest
 
     steps:
@@ -55,12 +55,21 @@ jobs:
       - name: Setup minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.16.1
         with:
-          minikube version: 'v1.32.0'
+          minikube version: 'v1.38.1'
           # the version of Kubernetes needs to be in-sync with `rebuild.sh`
-          kubernetes version: 'v1.27.10'
+          kubernetes version: 'v1.34.6'
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: docker
           start args: --addons=ingress --memory 4096 --cni cilium
+      - name: Configure the ingress
+        working-directory: provision/minikube
+        run: |
+          # Without those configuration changes the node ports of the ingress will not be reachable (since Kubernetes v1.28+)
+          kubectl -n kube-system patch configmap cilium-config \
+            --type merge \
+            -p '{"data":{"enable-node-port":"true","kube-proxy-replacement":"true","devices":"eth+ br+","node-port-bind-protection":"false"}}'
+          kubectl -n kube-system rollout restart daemonset/cilium
+          kubectl -n kube-system rollout status daemonset/cilium --timeout=120s
       - name: Provision on PostgreSQL DB
         working-directory: provision/minikube
         run: |

--- a/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-minikube.adoc
+++ b/doc/kubernetes/modules/ROOT/pages/prerequisite/prerequisite-minikube.adoc
@@ -56,7 +56,8 @@ minikube version
 
 Should print an output like:
 
+// Keep in-line with provision-minikube.yml
 ----
-minikube version: v1.25.2
+minikube version: v1.38.1
 commit: ...
 ----

--- a/provision/minikube/rebuild.sh
+++ b/provision/minikube/rebuild.sh
@@ -10,7 +10,8 @@ fi
 
 MINIKUBE_MEMORY=${MINIKUBE_MEMORY:-8192}
 MINIKUBE_CPUS=${MINIKUBE_CPUS:-4}
-MINIKUBE_KUBERNETES_VERSION=${MINIKUBE_KUBERNETES_VERSION:-1.30.0}
+# Keep this in line with `provision-minikube.yml`
+MINIKUBE_KUBERNETES_VERSION=${MINIKUBE_KUBERNETES_VERSION:-1.34.6}
 
 if [ "$GITHUB_ACTIONS" == "" ]; then
   #prerequisite checks
@@ -47,6 +48,13 @@ if [ "$GITHUB_ACTIONS" == "" ]; then
   minikube config set container-runtime docker
   # the version of Kubernetes needs to be in-sync with `provision-minikube.yml`
   minikube start --addons=ingress --disk-size=64GB --container-runtime=docker --driver=${DRIVER} --docker-opt="default-ulimit=nofile=102400:102400" --kubernetes-version=v$MINIKUBE_KUBERNETES_VERSION --cni cilium
+
+  # Without those configuration changes the node ports of the ingress will not be reachable (since Kubernetes v1.28+)
+  kubectl -n kube-system patch configmap cilium-config \
+    --type merge \
+    -p '{"data":{"enable-node-port":"true","kube-proxy-replacement":"true","devices":"eth+ br+","node-port-bind-protection":"false"}}'
+  kubectl -n kube-system rollout restart daemonset/cilium
+  kubectl -n kube-system rollout status daemonset/cilium --timeout=120s
 fi
 rm -rf .task
 echo "Minikube initialized. Now run 'task' to provision it with Keycloak"


### PR DESCRIPTION
With this setup the `isup.sh` is again working as expected.