### PR TITLE
Upgrade OpenShift version to `4.21`.

### DIFF
--- a/provision/opentofu/modules/rosa-hcp/variables.tf
+++ b/provision/opentofu/modules/rosa-hcp/variables.tf
@@ -51,7 +51,7 @@ variable "vpc_cidr" {
 
 variable "openshift_version" {
   type    = string
-  default = "4.18.30"
+  default = "4.21.8"
   nullable = false
 }
 


### PR DESCRIPTION
Latest version available for ROSA installation as of today is `4.21.8`.