### PR TITLE
Upgrade to Infinispan 16.0.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <keycloak.version>999.0.0-SNAPSHOT</keycloak.version>
     <keycloak-client.version>999.0.0-SNAPSHOT</keycloak-client.version>
-    <infinispan.version>16.0.12</infinispan.version>
+    <infinispan.version>16.0.14</infinispan.version>
     <junit5.version>5.10.1</junit5.version>
     <httpclient.version>4.5.14</httpclient.version>
     <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>

--- a/provision/infinispan/ispn-helm/values.yaml
+++ b/provision/infinispan/ispn-helm/values.yaml
@@ -7,8 +7,8 @@ replicas: 3
 # When 'useCustomImage' is 'false' then operator defaults will be used.
 # Values of 'image' and 'version' should be compatible with the deployed variant and version of Keycloak.
 useCustomImage: true
-image: quay.io/infinispan/server:16.0.12
-version: 16.0.12
+image: quay.io/infinispan/server:16.0.14
+version: 16.0.14
 cacheDefaults:
   owners: 2
   # SYNC or ASYNC


### PR DESCRIPTION
This PR holds the changes to upgrade the keycloak to infinispan to 16.0.14


Closes keycloak/keycloak-benchmark#1337

Signed-off-by: Ruchika <ruchika.jha1@ibm.com>